### PR TITLE
update rubyzip to 1.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       uber (< 0.2.0)
     retriable (3.1.1)
     rouge (2.0.7)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     security (0.1.3)
     signet (0.8.1)
       addressable (~> 2.3)

--- a/android/Gemfile.lock
+++ b/android/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       uber (< 0.2.0)
     retriable (3.1.1)
     rouge (2.0.7)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     security (0.1.3)
     signet (0.8.1)
       addressable (~> 2.3)


### PR DESCRIPTION
This addresses a vulnerability [CVE-2018-1000544](https://nvd.nist.gov/vuln/detail/CVE-2018-1000544)