### PR TITLE
Fix callback behavior when no explicit url is specified in the query

### DIFF
--- a/lib/sagas/requests/index.js
+++ b/lib/sagas/requests/index.js
@@ -330,7 +330,7 @@ export function * performCallback (request, response) {
   const callbackUrl = URL(request.callback_url)
   const redirectUrl = request.redirect_url ? URL(request.redirect_url) : undefined
 
-  if (request.postback !== false || callbackUrl.hostname.match(/^(chasqui|api)\.uport\.(me|space)$/)) {
+  if (request.postback === true || callbackUrl.hostname.match(/^(chasqui|api)\.uport\.(me|space)$/)) {
     yield call(postBackToServer, request, response)
     if (redirectUrl !== undefined) {
       return yield call(returnToApp, redirectUrl, undefined)


### PR DESCRIPTION
### What's here

This fixes #7
When using the unified request URL ( https://id.uport.me/req/... ) without an explicit callback type and url in the query, the app defaults to `postback` but because no postback url is set either, it does nothing with the response.

### Testing

Open the example URL in the description of #7 on a mobile device.
After accepting or rejecting the call, the app should call back to https://example.com