### PR TITLE
Adding pull to refresh on account funding screen

### DIFF
--- a/lib/components/Accounts/AccountFunding.js
+++ b/lib/components/Accounts/AccountFunding.js
@@ -17,7 +17,7 @@
 //
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Alert, Dimensions, DeviceInfo, Clipboard, Linking, Share, StyleSheet, Text, TouchableOpacity, View, ScrollView, Platform } from 'react-native'
+import { Alert, RefreshControl, Dimensions, DeviceInfo, Clipboard, Linking, Share, StyleSheet, Text, TouchableOpacity, View, ScrollView, Platform } from 'react-native'
 import { connect } from 'react-redux'
 import { toJs } from 'mori'
 import QRCode from 'react-native-qrcode'
@@ -27,6 +27,7 @@ import { colors } from 'uPortMobile/lib/styles/globalStyles'
 import { refreshBalance } from 'uPortMobile/lib/actions/uportActions'
 import { FAUCETS } from 'uPortMobile/lib/utilities/networks'
 import { capitalizeFirstLetter } from 'uPortMobile/lib/utilities/string'
+import { working } from 'uPortMobile/lib/selectors/processStatus'
 
 import { wei2eth } from 'uPortMobile/lib/helpers/conversions'
 
@@ -222,8 +223,9 @@ export class AccountFunding extends React.Component {
   }
 
   renderFaucetLink(network) {
+    const protocol = 'https'
     return (
-      <TouchableOpacity onPress={() => Linking.openURL(`https://${FAUCETS[network].url}`)}>
+      <TouchableOpacity onPress={() => Linking.openURL(`${protocol}://${FAUCETS[network].url}`)}>
         <Text style={styles.externalLink}> 
           { capitalizeFirstLetter(network) } <EvilIcon name='external-link' size={windowHeight * 0.025} color={colors.brand} />
         </Text>
@@ -239,7 +241,13 @@ export class AccountFunding extends React.Component {
             <EvilIcon name='x' size={windowHeight * 0.05} color={colors.brand} />
           </TouchableOpacity>
         </View>
-        <ScrollView>
+        <ScrollView 
+          refreshControl={
+            <RefreshControl
+              refreshing={!!this.props.working}
+              onRefresh={this.refreshBalanceHandler.bind(this)}
+            />
+          }>
           <View style={styles.screenContentContainer}>
             {
               this.state.showAddress || this.props.network === 'mainnet'
@@ -270,7 +278,8 @@ const mapStateToProps = (state, ownProps) => {
     usdBalance: usdBalance,
     address: settings.address,
     hexAddress: settings.hexaddress,
-    network: settings.network
+    network: settings.network,
+    working: working(state, 'balance'),
   }
 }
 


### PR DESCRIPTION
Fixing issue where user can't refresh their account balance from the funding screen.

User can now 'pull to refresh' their balance -

![simulator screen shot - iphone x - 2018-11-12 at 10 38 40](https://user-images.githubusercontent.com/7109973/48342322-3df0a080-e667-11e8-8c79-de2daeb04546.png)
