### PR TITLE
Disable disclosure buttons when error

### DIFF
--- a/lib/components/Notifications/__tests__/__snapshots__/AttestationNotification-test.js.snap
+++ b/lib/components/Notifications/__tests__/__snapshots__/AttestationNotification-test.js.snap
@@ -168,6 +168,7 @@ exports[`Attestation Notifications renders an attestation notification correctly
               Object {
                 "borderColor": "rgba(74,74,74,1)",
                 "borderWidth": 1,
+                "padding": 15,
               },
               Object {
                 "marginRight": 10,
@@ -219,7 +220,7 @@ exports[`Attestation Notifications renders an attestation notification correctly
             Array [
               Object {
                 "backgroundColor": "rgba(91,84,199,1)",
-                "marginLeft": 10,
+                "padding": 15,
               },
               undefined,
             ],

--- a/lib/components/Notifications/__tests__/__snapshots__/ConnectionNotification-test.js.snap
+++ b/lib/components/Notifications/__tests__/__snapshots__/ConnectionNotification-test.js.snap
@@ -189,6 +189,7 @@ exports[`Connection Notification renders an connection notification correctly 1`
               Object {
                 "borderColor": "rgba(74,74,74,1)",
                 "borderWidth": 1,
+                "padding": 15,
               },
               Object {
                 "marginRight": 10,
@@ -240,7 +241,7 @@ exports[`Connection Notification renders an connection notification correctly 1`
             Array [
               Object {
                 "backgroundColor": "rgba(91,84,199,1)",
-                "marginLeft": 10,
+                "padding": 15,
               },
               undefined,
             ],

--- a/lib/components/Notifications/__tests__/__snapshots__/DisclosureNotification-test.js.snap
+++ b/lib/components/Notifications/__tests__/__snapshots__/DisclosureNotification-test.js.snap
@@ -101,6 +101,7 @@ exports[`Disclosure Notification renders an disclosure notification correctly 1`
               Object {
                 "borderColor": "rgba(74,74,74,1)",
                 "borderWidth": 1,
+                "padding": 15,
               },
               Object {
                 "marginRight": 10,
@@ -152,7 +153,7 @@ exports[`Disclosure Notification renders an disclosure notification correctly 1`
             Array [
               Object {
                 "backgroundColor": "rgba(91,84,199,1)",
-                "marginLeft": 10,
+                "padding": 15,
               },
               undefined,
             ],

--- a/lib/components/Notifications/__tests__/__snapshots__/NetworkNotification-test.js.snap
+++ b/lib/components/Notifications/__tests__/__snapshots__/NetworkNotification-test.js.snap
@@ -101,6 +101,7 @@ exports[`Network Notification renders an network notification correctly 1`] = `
               Object {
                 "borderColor": "rgba(74,74,74,1)",
                 "borderWidth": 1,
+                "padding": 15,
               },
               Object {
                 "marginRight": 10,
@@ -152,7 +153,7 @@ exports[`Network Notification renders an network notification correctly 1`] = `
             Array [
               Object {
                 "backgroundColor": "rgba(91,84,199,1)",
-                "marginLeft": 10,
+                "padding": 15,
               },
               undefined,
             ],

--- a/lib/components/Notifications/__tests__/__snapshots__/Notifications-test.js.snap
+++ b/lib/components/Notifications/__tests__/__snapshots__/Notifications-test.js.snap
@@ -976,6 +976,7 @@ exports[`Notifications renders correctly with notifications 1`] = `
                         Object {
                           "borderColor": "rgba(74,74,74,1)",
                           "borderWidth": 1,
+                          "padding": 15,
                         },
                         Object {
                           "marginRight": 10,
@@ -1027,7 +1028,7 @@ exports[`Notifications renders correctly with notifications 1`] = `
                       Array [
                         Object {
                           "backgroundColor": "rgba(91,84,199,1)",
-                          "marginLeft": 10,
+                          "padding": 15,
                         },
                         undefined,
                       ],
@@ -1232,6 +1233,7 @@ exports[`Notifications renders correctly with notifications 1`] = `
                         Object {
                           "borderColor": "rgba(74,74,74,1)",
                           "borderWidth": 1,
+                          "padding": 15,
                         },
                         Object {
                           "marginRight": 10,
@@ -1283,7 +1285,7 @@ exports[`Notifications renders correctly with notifications 1`] = `
                       Array [
                         Object {
                           "backgroundColor": "rgba(91,84,199,1)",
-                          "marginLeft": 10,
+                          "padding": 15,
                         },
                         undefined,
                       ],
@@ -1421,6 +1423,7 @@ exports[`Notifications renders correctly with notifications 1`] = `
                         Object {
                           "borderColor": "rgba(74,74,74,1)",
                           "borderWidth": 1,
+                          "padding": 15,
                         },
                         Object {
                           "marginRight": 10,
@@ -1472,7 +1475,7 @@ exports[`Notifications renders correctly with notifications 1`] = `
                       Array [
                         Object {
                           "backgroundColor": "rgba(91,84,199,1)",
-                          "marginLeft": 10,
+                          "padding": 15,
                         },
                         undefined,
                       ],
@@ -1698,6 +1701,7 @@ exports[`Notifications renders correctly with notifications 1`] = `
                         Object {
                           "borderColor": "rgba(74,74,74,1)",
                           "borderWidth": 1,
+                          "padding": 15,
                         },
                         Object {
                           "marginRight": 10,
@@ -1749,7 +1753,7 @@ exports[`Notifications renders correctly with notifications 1`] = `
                       Array [
                         Object {
                           "backgroundColor": "rgba(91,84,199,1)",
-                          "marginLeft": 10,
+                          "padding": 15,
                         },
                         undefined,
                       ],
@@ -1964,6 +1968,7 @@ exports[`Notifications renders correctly with notifications 1`] = `
                         Object {
                           "borderColor": "rgba(74,74,74,1)",
                           "borderWidth": 1,
+                          "padding": 15,
                         },
                         Object {
                           "marginRight": 10,
@@ -2015,7 +2020,7 @@ exports[`Notifications renders correctly with notifications 1`] = `
                       Array [
                         Object {
                           "backgroundColor": "rgba(91,84,199,1)",
-                          "marginLeft": 10,
+                          "padding": 15,
                         },
                         undefined,
                       ],

--- a/lib/components/Notifications/__tests__/__snapshots__/TransactionNotification-test.js.snap
+++ b/lib/components/Notifications/__tests__/__snapshots__/TransactionNotification-test.js.snap
@@ -253,6 +253,7 @@ exports[`Transaction Notification renders an send ether notification correctly 1
               Object {
                 "borderColor": "rgba(74,74,74,1)",
                 "borderWidth": 1,
+                "padding": 15,
               },
               Object {
                 "marginRight": 10,
@@ -304,7 +305,7 @@ exports[`Transaction Notification renders an send ether notification correctly 1
             Array [
               Object {
                 "backgroundColor": "rgba(91,84,199,1)",
-                "marginLeft": 10,
+                "padding": 15,
               },
               undefined,
             ],
@@ -590,6 +591,7 @@ exports[`Transaction Notification renders an transaction notification correctly 
               Object {
                 "borderColor": "rgba(74,74,74,1)",
                 "borderWidth": 1,
+                "padding": 15,
               },
               Object {
                 "marginRight": 10,
@@ -641,7 +643,7 @@ exports[`Transaction Notification renders an transaction notification correctly 
             Array [
               Object {
                 "backgroundColor": "rgba(91,84,199,1)",
-                "marginLeft": 10,
+                "padding": 15,
               },
               undefined,
             ],
@@ -1377,6 +1379,7 @@ exports[`Transaction Notification renders an txhash notification correctly 1`] =
               Object {
                 "borderColor": "rgba(74,74,74,1)",
                 "borderWidth": 1,
+                "padding": 15,
               },
               Object {
                 "marginRight": 10,
@@ -1428,7 +1431,7 @@ exports[`Transaction Notification renders an txhash notification correctly 1`] =
             Array [
               Object {
                 "backgroundColor": "rgba(91,84,199,1)",
-                "marginLeft": 10,
+                "padding": 15,
               },
               undefined,
             ],
@@ -1714,6 +1717,7 @@ exports[`Transaction Notification renders an update uport transaction notificati
               Object {
                 "borderColor": "rgba(74,74,74,1)",
                 "borderWidth": 1,
+                "padding": 15,
               },
               Object {
                 "marginRight": 10,
@@ -1765,7 +1769,7 @@ exports[`Transaction Notification renders an update uport transaction notificati
             Array [
               Object {
                 "backgroundColor": "rgba(91,84,199,1)",
-                "marginLeft": 10,
+                "padding": 15,
               },
               undefined,
             ],

--- a/lib/components/Request/types/__tests__/__snapshots__/ConnectionCard-test.js.snap
+++ b/lib/components/Request/types/__tests__/__snapshots__/ConnectionCard-test.js.snap
@@ -1424,6 +1424,7 @@ exports[`ConnectionCard renders correctly with a complete profile 1`] = `
             Object {
               "borderColor": "rgba(74,74,74,1)",
               "borderWidth": 1,
+              "padding": 15,
             },
             Object {
               "marginRight": 10,
@@ -1475,7 +1476,7 @@ exports[`ConnectionCard renders correctly with a complete profile 1`] = `
           Array [
             Object {
               "backgroundColor": "rgba(91,84,199,1)",
-              "marginLeft": 10,
+              "padding": 15,
             },
             undefined,
           ],
@@ -2110,6 +2111,7 @@ exports[`ConnectionCard renders correctly with an unkown contact 1`] = `
             Object {
               "borderColor": "rgba(74,74,74,1)",
               "borderWidth": 1,
+              "padding": 15,
             },
             Object {
               "marginRight": 10,
@@ -2161,7 +2163,7 @@ exports[`ConnectionCard renders correctly with an unkown contact 1`] = `
           Array [
             Object {
               "backgroundColor": "rgba(91,84,199,1)",
-              "marginLeft": 10,
+              "padding": 15,
             },
             undefined,
           ],

--- a/lib/components/Request/types/__tests__/__snapshots__/DisclosureCard-test.js.snap
+++ b/lib/components/Request/types/__tests__/__snapshots__/DisclosureCard-test.js.snap
@@ -1032,6 +1032,7 @@ exports[`DisclosureCard renders correctly with a full disclosure request 1`] = `
             Object {
               "borderColor": "rgba(74,74,74,1)",
               "borderWidth": 1,
+              "padding": 15,
             },
             Object {
               "marginRight": 10,
@@ -1083,7 +1084,7 @@ exports[`DisclosureCard renders correctly with a full disclosure request 1`] = `
           Array [
             Object {
               "backgroundColor": "rgba(91,84,199,1)",
-              "marginLeft": 10,
+              "padding": 15,
             },
             undefined,
           ],
@@ -1616,6 +1617,7 @@ exports[`DisclosureCard renders correctly with a full disclosure request and cli
             Object {
               "borderColor": "rgba(74,74,74,1)",
               "borderWidth": 1,
+              "padding": 15,
             },
             Object {
               "marginRight": 10,
@@ -1667,7 +1669,7 @@ exports[`DisclosureCard renders correctly with a full disclosure request and cli
           Array [
             Object {
               "backgroundColor": "rgba(91,84,199,1)",
-              "marginLeft": 10,
+              "padding": 15,
             },
             undefined,
           ],
@@ -2220,6 +2222,7 @@ exports[`DisclosureCard renders correctly with a full disclosure request and ver
             Object {
               "borderColor": "rgba(74,74,74,1)",
               "borderWidth": 1,
+              "padding": 15,
             },
             Object {
               "marginRight": 10,
@@ -2271,7 +2274,7 @@ exports[`DisclosureCard renders correctly with a full disclosure request and ver
           Array [
             Object {
               "backgroundColor": "rgba(91,84,199,1)",
-              "marginLeft": 10,
+              "padding": 15,
             },
             undefined,
           ],
@@ -2858,6 +2861,7 @@ exports[`DisclosureCard renders correctly with a full disclosure request with pu
             Object {
               "borderColor": "rgba(74,74,74,1)",
               "borderWidth": 1,
+              "padding": 15,
             },
             Object {
               "marginRight": 10,
@@ -2910,6 +2914,7 @@ exports[`DisclosureCard renders correctly with a full disclosure request with pu
             "backgroundColor": "rgba(0,0,0,0)",
             "borderColor": "rgba(185, 185, 185, 1)",
             "borderWidth": 1,
+            "padding": 15,
           },
         ]
       }
@@ -3496,6 +3501,7 @@ exports[`DisclosureCard renders correctly with a full disclosure request with pu
             Object {
               "borderColor": "rgba(74,74,74,1)",
               "borderWidth": 1,
+              "padding": 15,
             },
             Object {
               "marginRight": 10,
@@ -3547,7 +3553,7 @@ exports[`DisclosureCard renders correctly with a full disclosure request with pu
           Array [
             Object {
               "backgroundColor": "rgba(91,84,199,1)",
-              "marginLeft": 10,
+              "padding": 15,
             },
             undefined,
           ],
@@ -4134,6 +4140,7 @@ exports[`DisclosureCard renders correctly with a full disclosure request with pu
             Object {
               "borderColor": "rgba(74,74,74,1)",
               "borderWidth": 1,
+              "padding": 15,
             },
             Object {
               "marginRight": 10,
@@ -4185,7 +4192,7 @@ exports[`DisclosureCard renders correctly with a full disclosure request with pu
           Array [
             Object {
               "backgroundColor": "rgba(91,84,199,1)",
-              "marginLeft": 10,
+              "padding": 15,
             },
             undefined,
           ],
@@ -4718,6 +4725,7 @@ exports[`DisclosureCard renders correctly with a segregated account request and 
             Object {
               "borderColor": "rgba(74,74,74,1)",
               "borderWidth": 1,
+              "padding": 15,
             },
             Object {
               "marginRight": 10,
@@ -4769,7 +4777,7 @@ exports[`DisclosureCard renders correctly with a segregated account request and 
           Array [
             Object {
               "backgroundColor": "rgba(91,84,199,1)",
-              "marginLeft": 10,
+              "padding": 15,
             },
             undefined,
           ],
@@ -5302,6 +5310,7 @@ exports[`DisclosureCard renders correctly with a simple request and client info 
             Object {
               "borderColor": "rgba(74,74,74,1)",
               "borderWidth": 1,
+              "padding": 15,
             },
             Object {
               "marginRight": 10,
@@ -5353,7 +5362,7 @@ exports[`DisclosureCard renders correctly with a simple request and client info 
           Array [
             Object {
               "backgroundColor": "rgba(91,84,199,1)",
-              "marginLeft": 10,
+              "padding": 15,
             },
             undefined,
           ],
@@ -5907,6 +5916,7 @@ exports[`DisclosureCard renders correctly with error 1`] = `
             Object {
               "borderColor": "rgba(74,74,74,1)",
               "borderWidth": 1,
+              "padding": 15,
             },
             Object {
               "marginRight": 10,
@@ -5959,6 +5969,7 @@ exports[`DisclosureCard renders correctly with error 1`] = `
             "backgroundColor": "rgba(0,0,0,0)",
             "borderColor": "rgba(185, 185, 185, 1)",
             "borderWidth": 1,
+            "padding": 15,
           },
         ]
       }
@@ -6491,6 +6502,7 @@ exports[`DisclosureCard unpublished identity renders correctly after publishing 
             Object {
               "borderColor": "rgba(74,74,74,1)",
               "borderWidth": 1,
+              "padding": 15,
             },
             Object {
               "marginRight": 10,
@@ -6542,7 +6554,7 @@ exports[`DisclosureCard unpublished identity renders correctly after publishing 
           Array [
             Object {
               "backgroundColor": "rgba(91,84,199,1)",
-              "marginLeft": 10,
+              "padding": 15,
             },
             undefined,
           ],
@@ -7075,6 +7087,7 @@ exports[`DisclosureCard unpublished identity renders correctly with identity not
             Object {
               "borderColor": "rgba(74,74,74,1)",
               "borderWidth": 1,
+              "padding": 15,
             },
             Object {
               "marginRight": 10,
@@ -7126,7 +7139,7 @@ exports[`DisclosureCard unpublished identity renders correctly with identity not
           Array [
             Object {
               "backgroundColor": "rgba(91,84,199,1)",
-              "marginLeft": 10,
+              "padding": 15,
             },
             undefined,
           ],
@@ -7765,6 +7778,7 @@ exports[`DisclosureCard with network with no existing account for network render
             Object {
               "borderColor": "rgba(74,74,74,1)",
               "borderWidth": 1,
+              "padding": 15,
             },
             Object {
               "marginRight": 10,
@@ -7816,7 +7830,7 @@ exports[`DisclosureCard with network with no existing account for network render
           Array [
             Object {
               "backgroundColor": "rgba(91,84,199,1)",
-              "marginLeft": 10,
+              "padding": 15,
             },
             undefined,
           ],
@@ -8455,6 +8469,7 @@ exports[`DisclosureCard with network with no existing segregated account for cli
             Object {
               "borderColor": "rgba(74,74,74,1)",
               "borderWidth": 1,
+              "padding": 15,
             },
             Object {
               "marginRight": 10,
@@ -8506,7 +8521,7 @@ exports[`DisclosureCard with network with no existing segregated account for cli
           Array [
             Object {
               "backgroundColor": "rgba(91,84,199,1)",
-              "marginLeft": 10,
+              "padding": 15,
             },
             undefined,
           ],
@@ -9145,6 +9160,7 @@ exports[`DisclosureCard with network with pre-existing account renders correctly
             Object {
               "borderColor": "rgba(74,74,74,1)",
               "borderWidth": 1,
+              "padding": 15,
             },
             Object {
               "marginRight": 10,
@@ -9196,7 +9212,7 @@ exports[`DisclosureCard with network with pre-existing account renders correctly
           Array [
             Object {
               "backgroundColor": "rgba(91,84,199,1)",
-              "marginLeft": 10,
+              "padding": 15,
             },
             undefined,
           ],

--- a/lib/components/Request/types/__tests__/__snapshots__/NetworkCard-test.js.snap
+++ b/lib/components/Request/types/__tests__/__snapshots__/NetworkCard-test.js.snap
@@ -1168,6 +1168,7 @@ exports[`NetworkCard renders new request correctly 1`] = `
             Object {
               "borderColor": "rgba(74,74,74,1)",
               "borderWidth": 1,
+              "padding": 15,
             },
             Object {
               "marginRight": 10,
@@ -1219,7 +1220,7 @@ exports[`NetworkCard renders new request correctly 1`] = `
           Array [
             Object {
               "backgroundColor": "rgba(91,84,199,1)",
-              "marginLeft": 10,
+              "padding": 15,
             },
             undefined,
           ],
@@ -1600,6 +1601,7 @@ exports[`NetworkCard renders request with errors 1`] = `
             Object {
               "borderColor": "rgba(74,74,74,1)",
               "borderWidth": 1,
+              "padding": 15,
             },
             Object {
               "marginRight": 10,
@@ -1652,6 +1654,7 @@ exports[`NetworkCard renders request with errors 1`] = `
             "backgroundColor": "rgba(0,0,0,0)",
             "borderColor": "rgba(185, 185, 185, 1)",
             "borderWidth": 1,
+            "padding": 15,
           },
         ]
       }

--- a/lib/components/Request/types/__tests__/__snapshots__/TransactionCard-test.js.snap
+++ b/lib/components/Request/types/__tests__/__snapshots__/TransactionCard-test.js.snap
@@ -272,7 +272,7 @@ exports[`TransactionCard renders correctly with abi with args and a no value 1`]
             Array [
               Object {
                 "backgroundColor": "rgba(91,84,199,1)",
-                "marginLeft": 10,
+                "padding": 15,
               },
               Object {
                 "marginBottom": 30,
@@ -617,6 +617,7 @@ exports[`TransactionCard renders correctly with abi without args and value 1`] =
               Object {
                 "borderColor": "rgba(74,74,74,1)",
                 "borderWidth": 1,
+                "padding": 15,
               },
               Object {
                 "alignItems": "center",
@@ -937,7 +938,7 @@ exports[`TransactionCard renders correctly with both client and destination 1`] 
             Array [
               Object {
                 "backgroundColor": "rgba(91,84,199,1)",
-                "marginLeft": 10,
+                "padding": 15,
               },
               Object {
                 "marginBottom": 30,
@@ -1524,7 +1525,7 @@ exports[`TransactionCard renders correctly with destination being validated 1`] 
             Array [
               Object {
                 "backgroundColor": "rgba(91,84,199,1)",
-                "marginLeft": 10,
+                "padding": 15,
               },
               Object {
                 "marginBottom": 30,
@@ -1840,7 +1841,7 @@ exports[`TransactionCard renders correctly with only request 1`] = `
             Array [
               Object {
                 "backgroundColor": "rgba(91,84,199,1)",
-                "marginLeft": 10,
+                "padding": 15,
               },
               Object {
                 "marginBottom": 30,
@@ -2156,7 +2157,7 @@ exports[`TransactionCard renders correctly with publicUportTransaction 1`] = `
             Array [
               Object {
                 "backgroundColor": "rgba(91,84,199,1)",
-                "marginLeft": 10,
+                "padding": 15,
               },
               Object {
                 "marginBottom": 30,
@@ -2472,7 +2473,7 @@ exports[`TransactionCard renders correctly with request and a 0 value 1`] = `
             Array [
               Object {
                 "backgroundColor": "rgba(91,84,199,1)",
-                "marginLeft": 10,
+                "padding": 15,
               },
               Object {
                 "marginBottom": 30,
@@ -2788,7 +2789,7 @@ exports[`TransactionCard renders correctly with request and a value 1`] = `
             Array [
               Object {
                 "backgroundColor": "rgba(91,84,199,1)",
-                "marginLeft": 10,
+                "padding": 15,
               },
               Object {
                 "marginBottom": 30,
@@ -3104,7 +3105,7 @@ exports[`TransactionCard renders correctly with request and a value with insuffi
             Array [
               Object {
                 "backgroundColor": "rgba(91,84,199,1)",
-                "marginLeft": 10,
+                "padding": 15,
               },
               Object {
                 "marginBottom": 30,

--- a/lib/components/newRequest/types/DisclosureCard.js
+++ b/lib/components/newRequest/types/DisclosureCard.js
@@ -129,7 +129,7 @@ const styles = StyleSheet.create({
 })
 
 const parseErrorMessage = (message) => {
-  return message.startsWith('JWT has expired') ? 'This credential has expired. Please contact the issuer.' : message
+  return message.startsWith('JWT has expired') ? 'This credential has expired.' : message
 }
 
 export const DisclosureCard = (props) => {

--- a/lib/components/newRequest/types/DisclosureCard.js
+++ b/lib/components/newRequest/types/DisclosureCard.js
@@ -128,6 +128,10 @@ const styles = StyleSheet.create({
   },
 })
 
+const parseErrorMessage = (message) => {
+  return message.startsWith('JWT has expired') ? 'This credential has expired. Please contact the issuer.' : message
+}
+
 export const DisclosureCard = (props) => {
   const showUrl = props.client && props.client.url !== undefined
 
@@ -153,7 +157,7 @@ style={{width: windowWidth * 0.22, height: windowWidth * 0.22, borderRadius: 3}}
     <View> 
 
 
-    <View style={{alignItems: 'stretch', flex: 1, backgroundColor: '#F6F5FE'}}>
+    <View style={{alignItems: 'stretch', flex: 1, backgroundColor: '#F6F5FE', paddingBottom: 20}}>
       <View style={[styles.disclosureBar, {marginBottom: 0, paddingBottom: 10}]}>
         <Text style={[styles.cardTitle, {textAlign: 'left'}]}>Login</Text>
         <TouchableOpacity
@@ -203,8 +207,8 @@ style={{width: windowWidth * 0.22, height: windowWidth * 0.22, borderRadius: 3}}
       : null }
 
       { props.error
-        ? <Text style={[textStyles.small, {color: 'red'}]}>
-          { props.error }
+        ? <Text style={{borderColor: '#C94444', padding: 10, margin: 15, marginBottom: 0, backgroundColor: '#E86B6B', fontSize: 14, color: colors.white, textAlign: 'center'}}>
+          { parseErrorMessage(props.error) }
         </Text>
         : null }
       
@@ -227,12 +231,14 @@ style={{width: windowWidth * 0.22, height: windowWidth * 0.22, borderRadius: 3}}
 
       { (props.actType === 'none' || props.accountAuthorized === true)
       ? <PrimaryButton
+        disabled={props.error && true}
         onPress={() => props.authorizeRequest(props.requestId)}
-        style={{marginLeft: 16, marginRight: 16, marginTop: 0, marginBottom: 30}}>
+        style={{padding: 15}}>
         <Text style={{fontSize: 14}}> SHARE YOUR INFORMATION </Text>
       </PrimaryButton> : null }
       { ((props.actType !== 'none') && !props.account && props.accountAuthorized === false)
         ? <PrimaryButton
+          disabled={props.error && true}
           onPress={() => props.authorizeAccount(props.requestId, 'new')}
           style={{marginLeft: 16, marginRight: 16, marginTop: 0, marginBottom: 30}}>
           <Text style={{fontSize: 14}}> CREATE NEW ACCOUNT </Text>

--- a/lib/components/newRequest/types/__tests__/__snapshots__/DisclosureCard-test.js.snap
+++ b/lib/components/newRequest/types/__tests__/__snapshots__/DisclosureCard-test.js.snap
@@ -78,6 +78,7 @@ ShallowWrapper {
                 "alignItems": "stretch",
                 "backgroundColor": "#F6F5FE",
                 "flex": 1,
+                "paddingBottom": 20,
               }
             }
           >
@@ -249,6 +250,7 @@ ShallowWrapper {
                 "alignItems": "stretch",
                 "backgroundColor": "#F6F5FE",
                 "flex": 1,
+                "paddingBottom": 20,
               }
             }
           >
@@ -441,6 +443,7 @@ ShallowWrapper {
               "alignItems": "stretch",
               "backgroundColor": "#F6F5FE",
               "flex": 1,
+              "paddingBottom": 20,
             },
           },
           "ref": null,
@@ -599,6 +602,7 @@ ShallowWrapper {
                 >
                    CREATE NEW ACCOUNT 
                 </Text>,
+                "disabled": undefined,
                 "onPress": [Function],
                 "style": Object {
                   "marginBottom": 30,
@@ -676,6 +680,7 @@ ShallowWrapper {
                   "alignItems": "stretch",
                   "backgroundColor": "#F6F5FE",
                   "flex": 1,
+                  "paddingBottom": 20,
                 }
               }
             >
@@ -847,6 +852,7 @@ ShallowWrapper {
                   "alignItems": "stretch",
                   "backgroundColor": "#F6F5FE",
                   "flex": 1,
+                  "paddingBottom": 20,
                 }
               }
             >
@@ -1039,6 +1045,7 @@ ShallowWrapper {
                 "alignItems": "stretch",
                 "backgroundColor": "#F6F5FE",
                 "flex": 1,
+                "paddingBottom": 20,
               },
             },
             "ref": null,
@@ -1197,6 +1204,7 @@ ShallowWrapper {
                   >
                      CREATE NEW ACCOUNT 
                   </Text>,
+                  "disabled": undefined,
                   "onPress": [Function],
                   "style": Object {
                     "marginBottom": 30,
@@ -1343,6 +1351,7 @@ exports[`DisclosureCard renders correctly with a full disclosure request 1`] = `
           "alignItems": "stretch",
           "backgroundColor": "#F6F5FE",
           "flex": 1,
+          "paddingBottom": 20,
         }
       }
     >
@@ -1506,6 +1515,7 @@ exports[`DisclosureCard renders correctly with a full disclosure request and cli
           "alignItems": "stretch",
           "backgroundColor": "#F6F5FE",
           "flex": 1,
+          "paddingBottom": 20,
         }
       }
     >
@@ -1669,6 +1679,7 @@ exports[`DisclosureCard renders correctly with a full disclosure request and ver
           "alignItems": "stretch",
           "backgroundColor": "#F6F5FE",
           "flex": 1,
+          "paddingBottom": 20,
         }
       }
     >
@@ -1832,6 +1843,7 @@ exports[`DisclosureCard renders correctly with a full disclosure request with pu
           "alignItems": "stretch",
           "backgroundColor": "#F6F5FE",
           "flex": 1,
+          "paddingBottom": 20,
         }
       }
     >
@@ -1995,6 +2007,7 @@ exports[`DisclosureCard renders correctly with a full disclosure request with pu
           "alignItems": "stretch",
           "backgroundColor": "#F6F5FE",
           "flex": 1,
+          "paddingBottom": 20,
         }
       }
     >
@@ -2158,6 +2171,7 @@ exports[`DisclosureCard renders correctly with a full disclosure request with pu
           "alignItems": "stretch",
           "backgroundColor": "#F6F5FE",
           "flex": 1,
+          "paddingBottom": 20,
         }
       }
     >
@@ -2321,6 +2335,7 @@ exports[`DisclosureCard renders correctly with a segregated account request and 
           "alignItems": "stretch",
           "backgroundColor": "#F6F5FE",
           "flex": 1,
+          "paddingBottom": 20,
         }
       }
     >
@@ -2484,6 +2499,7 @@ exports[`DisclosureCard renders correctly with a simple request and client info 
           "alignItems": "stretch",
           "backgroundColor": "#F6F5FE",
           "flex": 1,
+          "paddingBottom": 20,
         }
       }
     >
@@ -2647,6 +2663,7 @@ exports[`DisclosureCard renders correctly with error 1`] = `
           "alignItems": "stretch",
           "backgroundColor": "#F6F5FE",
           "flex": 1,
+          "paddingBottom": 20,
         }
       }
     >
@@ -2722,18 +2739,16 @@ exports[`DisclosureCard renders correctly with error 1`] = `
         allowFontScaling={true}
         ellipsizeMode="tail"
         style={
-          Array [
-            Object {
-              "color": "rgba(155,155,155,1)",
-              "fontFamily": "NunitoSans-Light",
-              "fontSize": 14,
-              "lineHeight": 19,
-              "textAlign": "center",
-            },
-            Object {
-              "color": "red",
-            },
-          ]
+          Object {
+            "backgroundColor": "#E86B6B",
+            "borderColor": "#C94444",
+            "color": "#FFFFFF",
+            "fontSize": 14,
+            "margin": 15,
+            "marginBottom": 0,
+            "padding": 10,
+            "textAlign": "center",
+          }
         }
       >
         JWT has Expired
@@ -2831,6 +2846,7 @@ exports[`DisclosureCard unpublished identity renders correctly after publishing 
           "alignItems": "stretch",
           "backgroundColor": "#F6F5FE",
           "flex": 1,
+          "paddingBottom": 20,
         }
       }
     >
@@ -2994,6 +3010,7 @@ exports[`DisclosureCard unpublished identity renders correctly with identity not
           "alignItems": "stretch",
           "backgroundColor": "#F6F5FE",
           "flex": 1,
+          "paddingBottom": 20,
         }
       }
     >
@@ -3157,6 +3174,7 @@ exports[`DisclosureCard with network with no existing account for network render
           "alignItems": "stretch",
           "backgroundColor": "#F6F5FE",
           "flex": 1,
+          "paddingBottom": 20,
         }
       }
     >
@@ -3320,6 +3338,7 @@ exports[`DisclosureCard with network with no existing segregated account for cli
           "alignItems": "stretch",
           "backgroundColor": "#F6F5FE",
           "flex": 1,
+          "paddingBottom": 20,
         }
       }
     >
@@ -3483,6 +3502,7 @@ exports[`DisclosureCard with network with pre-existing account renders correctly
           "alignItems": "stretch",
           "backgroundColor": "#F6F5FE",
           "flex": 1,
+          "paddingBottom": 20,
         }
       }
     >

--- a/lib/components/newRequest/types/__tests__/__snapshots__/TransactionCard-test.js.snap
+++ b/lib/components/newRequest/types/__tests__/__snapshots__/TransactionCard-test.js.snap
@@ -383,7 +383,7 @@ there
                 Array [
                   Object {
                     "backgroundColor": "rgba(91,84,199,1)",
-                    "marginLeft": 10,
+                    "padding": 15,
                   },
                   Object {
                     "marginBottom": 30,
@@ -806,7 +806,7 @@ exports[`TransactionCard renders correctly with abi without args and value 1`] =
                 Array [
                   Object {
                     "backgroundColor": "rgba(91,84,199,1)",
-                    "marginLeft": 10,
+                    "padding": 15,
                   },
                   Object {
                     "marginBottom": 30,
@@ -1184,7 +1184,7 @@ exports[`TransactionCard renders correctly with both client and destination 1`] 
                 Array [
                   Object {
                     "backgroundColor": "rgba(91,84,199,1)",
-                    "marginLeft": 10,
+                    "padding": 15,
                   },
                   Object {
                     "marginBottom": 30,
@@ -1975,7 +1975,7 @@ exports[`TransactionCard renders correctly with destination being validated 1`] 
                 Array [
                   Object {
                     "backgroundColor": "rgba(91,84,199,1)",
-                    "marginLeft": 10,
+                    "padding": 15,
                   },
                   Object {
                     "marginBottom": 30,
@@ -2353,7 +2353,7 @@ exports[`TransactionCard renders correctly with only request 1`] = `
                 Array [
                   Object {
                     "backgroundColor": "rgba(91,84,199,1)",
-                    "marginLeft": 10,
+                    "padding": 15,
                   },
                   Object {
                     "marginBottom": 30,
@@ -2778,7 +2778,7 @@ exports[`TransactionCard renders correctly with publicUportTransaction 1`] = `
                 Array [
                   Object {
                     "backgroundColor": "rgba(91,84,199,1)",
-                    "marginLeft": 10,
+                    "padding": 15,
                   },
                   Object {
                     "marginBottom": 30,
@@ -3156,7 +3156,7 @@ exports[`TransactionCard renders correctly with request and a 0 value 1`] = `
                 Array [
                   Object {
                     "backgroundColor": "rgba(91,84,199,1)",
-                    "marginLeft": 10,
+                    "padding": 15,
                   },
                   Object {
                     "marginBottom": 30,
@@ -3534,7 +3534,7 @@ exports[`TransactionCard renders correctly with request and a value 1`] = `
                 Array [
                   Object {
                     "backgroundColor": "rgba(91,84,199,1)",
-                    "marginLeft": 10,
+                    "padding": 15,
                   },
                   Object {
                     "marginBottom": 30,
@@ -3912,7 +3912,7 @@ exports[`TransactionCard renders correctly with request and a value with insuffi
                 Array [
                   Object {
                     "backgroundColor": "rgba(91,84,199,1)",
-                    "marginLeft": 10,
+                    "padding": 15,
                   },
                   Object {
                     "marginBottom": 30,

--- a/lib/components/shared/Button.js
+++ b/lib/components/shared/Button.js
@@ -31,17 +31,18 @@ const styles = StyleSheet.create({
   },
   cancelButton: {
     borderColor: colors.grey74,
-    borderWidth: 1
-    // marginRight: 10
+    borderWidth: 1,
+    padding: 15
   },
   primaryButton: {
     backgroundColor: colors.lightPurple,
-    marginLeft: 10
+    padding: 15
   },
   disabledButton: {
     borderWidth: 1,
     borderColor: colors.grey185,
-    backgroundColor: 'rgba(0,0,0,0)'
+    backgroundColor: 'rgba(0,0,0,0)',
+    padding: 15
   },
   buttonText: {
     fontFamily: fontBold,

--- a/lib/components/shared/__tests__/__snapshots__/ProcessCard-test.js.snap
+++ b/lib/components/shared/__tests__/__snapshots__/ProcessCard-test.js.snap
@@ -287,6 +287,7 @@ exports[`disabled button invalid state 1`] = `
                   "backgroundColor": "rgba(0,0,0,0)",
                   "borderColor": "rgba(185, 185, 185, 1)",
                   "borderWidth": 1,
+                  "padding": 15,
                 },
               ]
             }
@@ -637,6 +638,7 @@ exports[`disabled button working 1`] = `
                   "backgroundColor": "rgba(0,0,0,0)",
                   "borderColor": "rgba(185, 185, 185, 1)",
                   "borderWidth": 1,
+                  "padding": 15,
                 },
               ]
             }
@@ -825,6 +827,7 @@ exports[`disabled button working and message 1`] = `
                   "backgroundColor": "rgba(0,0,0,0)",
                   "borderColor": "rgba(185, 185, 185, 1)",
                   "borderWidth": 1,
+                  "padding": 15,
                 },
               ]
             }


### PR DESCRIPTION
Disable disclosure buttons when theres an error. Attempting to create a new account if an error exists results in the app freezing.

This is how it will now look:

![img_0827](https://user-images.githubusercontent.com/7109973/48950548-74fe6600-ef33-11e8-8301-7fc512a1f548.PNG)
