### PR TITLE
Showing client avatar image

### DIFF
--- a/lib/components/newRequest/types/DisclosureCard.js
+++ b/lib/components/newRequest/types/DisclosureCard.js
@@ -149,7 +149,7 @@ export const DisclosureCard = (props) => {
       <View style={{flex: 0, justifyContent: 'center', alignItems: 'center'}}>
         { props.client && props.client.avatar ? <Image resizeMode='cover'
           source={props.client.avatar}
-          style={{borderRadius: 3}} /> : null }
+          style={{borderRadius: 3, height: 70, width: 70}} /> : null }
       </View>
       {showUrl && <View style={styles.url}>
           <TouchableOpacity onPress={() => Linking.openURL(props.client.url)}>

--- a/lib/components/newRequest/types/TransactionCard.js
+++ b/lib/components/newRequest/types/TransactionCard.js
@@ -369,7 +369,7 @@ export class TransactionCard extends React.Component {
         <View style={{flex: 0, justifyContent: 'center', alignItems: 'center'}}>
           { this.props.client && this.props.client.avatar ? <Image resizeMode='cover'
             source={this.props.client.avatar} 
-            style={{borderRadius: 3}} /> : null }
+            style={{borderRadius: 3, height: 70, width: 70}} /> : null }
           {showUrl && <View style={styles.url}>
             <TouchableOpacity onPress={() => Linking.openURL(this.props.client.url)}>
               <Text style={{color: "white"}}>{this.props.client.url}</Text>


### PR DESCRIPTION
This PR fixes bug introduced with in https://github.com/uport-project/uport-mobile/pull/12 where client avatar was invisible on DisclosureCard and TransactionCard