### PR TITLE
fix build for react-native subprojects

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,6 +80,18 @@ allprojects {
 }
 
 subprojects { subproject ->
+
+    def name = subproject.name
+    if (name.contains('react-native')) {
+        buildscript {
+            repositories {
+                google()
+                jcenter()
+                maven { url "https://dl.bintray.com/android/android-tools/"  }
+            }
+        }
+    }
+
     afterEvaluate {
         if ((subproject.plugins.hasPlugin('android') || subproject.plugins.hasPlugin('android-library'))) {
             android {


### PR DESCRIPTION
### What's here

This PR is a fix for the recent build issues with react-native dependencies.
Most RN dependencies use old and/or deprecated build tools.
It seems that `jcenter` is not serving these old versions anymore.
This would not be problematic if they didn't also try to force the use of these old tools by pinning the repositories where they search.
This PR broadens the repository definitions for these RN subprojects so they have more places to find their unmaintained build tools.

### Testing

If you run `./gradlew clean assembleDebug` in the `android` folder and it builds successfully, then it's fixed.