### PR TITLE
execute callback if callbackUrl is included in claim when adding attestation

### DIFF
--- a/lib/sagas/requests/addAttestations.js
+++ b/lib/sagas/requests/addAttestations.js
@@ -15,12 +15,13 @@
 // You should have received a copy of the GNU General Public License
 // along with uPort Mobile App.  If not, see <http://www.gnu.org/licenses/>.
 //
-import { takeEvery, put, select, call, fork } from 'redux-saga/effects'
+import { takeEvery, put, select, call, fork, spawn } from 'redux-saga/effects'
 import { ADD_ATTESTATION } from 'uPortMobile/lib/constants/UportActionTypes'
 import { updateActivity, removeActivity, updateInteractionStats, storeAttestation, removePendingAttestation } from 'uPortMobile/lib/actions/uportActions'
 import { verifyToken } from '../jwt'
 import { track } from 'uPortMobile/lib/actions/metricActions'
 import { addMultipleVc } from '../vcSaga'
+import { performCallback } from './index'
 
 export function * reject (request, error) {
   yield put(removeActivity(request.id))
@@ -44,6 +45,13 @@ export function * handle (verified, jwt) {
   yield put(storeAttestation(verified))
   yield put(updateInteractionStats(verified.sub, verified.iss, 'attest'))
   yield put(removePendingAttestation(verified.sub, verified.iss, Object.keys(verified.claim)[0]))
+  if (verified.callbackUrl) {
+    yield spawn(performCallback, {
+      callback_url: verified.callbackUrl,
+      postback: true
+    }, { status: 'accepted', jwt })
+  }
+
   return request
 }
 


### PR DESCRIPTION
When mobile app detects a `callbackUrl` param in the claim of an add attestation request, it will POST to that url.  The response payload will be `{ status: 'accepted', jwt: <attestation JWT> }`

This fix is an urgent response to the issues experienced by Sobol.