### PR TITLE
[Bugfix] startup crash on android 9

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -250,7 +250,8 @@ configurations.all {
                 "com.google.firebase:firebase-core:$play_services_version",
                 "com.google.firebase:firebase-messaging:$play_services_version",
                 "com.google.android.gms:play-services-gcm:$play_services_version",
-                "com.android.support:support-v4:$support_lib_version"
+                "com.android.support:support-v4:$support_lib_version",
+                "com.android.support:appcompat-v7:$support_lib_version",
         )
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ buildscript {
         constraint_layout_version = "1.1.2"
         support_lib_version = "28.0.0"
         play_services_version = "12.0.1"
-        aws_lib_version = "2.6.7"
+        aws_lib_version = "2.9.1"
         okhttp_version = "3.10.0"
         crashlytics_version = "2.9.4"
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "lint": "./node_modules/.bin/standard",
     "lint-fix": "./node_modules/.bin/standard --fix",
     "test": "jest",
-    "package-android": "mkdir -p android/app/build/jsbundle/assets/ && mkdir -p android/app/build/jsbundle/res && node node_modules/react-native/local-cli/cli.js bundle --platform android --dev false --entry-file index.android.js --bundle-output android/app/build/jsbundle/assets/index.android.bundle --assets-dest android/app/build/jsbundle/res"
+    "package-android": "mkdir -p android/app/build/jsbundle/assets/ && mkdir -p android/app/build/jsbundle/res && node node_modules/react-native/local-cli/cli.js bundle --platform android --dev false --entry-file index.android.js --bundle-output android/app/build/jsbundle/assets/index.android.bundle --assets-dest android/app/build/jsbundle/res",
+    "package-android-release": "cd android && ./gradlew clean && cd - && mkdir -p android/app/build/jsbundle/assets/ && mkdir -p android/app/build/jsbundle/res && node node_modules/react-native/local-cli/cli.js bundle --platform android --dev false --entry-file index.android.js --bundle-output android/app/build/jsbundle/assets/index.android.bundle --assets-dest android/app/build/jsbundle/res && cd android && ./gradlew deliverArchives -x bundleReleaseJsAndAssets",
+    "package-android-dummy": "cd android && ./gradlew clean && cd - && mkdir -p android/app/build/jsbundle/assets/ && mkdir -p android/app/build/jsbundle/res && node node_modules/react-native/local-cli/cli.js bundle --platform android --dev false --entry-file index.android.js --bundle-output android/app/build/jsbundle/assets/index.android.bundle --assets-dest android/app/build/jsbundle/res && cd android && ./gradlew deliverArchives -x bundleReleaseJsAndAssets -PIGNORE_VAULT=true -PIGNORE_REPOSITORY_STATE=true"
   },
   "jest": {
     "preset": "react-native",


### PR DESCRIPTION
### What's here

App crashes on android 9 shortly after startup with a stacktrace pointing to aws utils.
The relevant fix in the amazon stack is here: https://github.com/aws-amplify/aws-sdk-android/issues/476

This PR updates the amazon dependencies.

### Note

I added some shortcuts to build release versions since I was unable to run the debug version of the app on api 28