### PR TITLE
Publish android to internal track

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
       - run: wget https://releases.hashicorp.com/vault/0.10.1/vault_0.10.1_linux_amd64.zip -O ~/vault.zip
       - run: unzip ~/vault.zip -d ~/vault/
 
-      - run: PATH=$PATH:$HOME/vault && bash ../scripts/pull_service_key.sh && fastlane android alpha; rm -f ../google-play-key-file.json
+      - run: PATH=$PATH:$HOME/vault && bash ../scripts/pull_service_key.sh && fastlane android internal; rm -f ../google-play-key-file.json
   deploy-ios:
     working_directory: ~/uport-mobile
     environment:

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -49,6 +49,29 @@ platform :android do
     )
   end
 
+  desc "Submit a new Release Build to Google Play Internal testing channel"
+  lane :internal do
+
+    ## the app should already be built by CircleCI, no need to call this again
+    # gradle(
+    #  task: 'deliverArchives'
+    # )
+
+    upload_to_play_store(
+      track: 'internal',
+      apk_paths: [
+        './app/build/outputs/apk/release/app-armeabi-v7a-release.apk',
+        './app/build/outputs/apk/release/app-x86-release.apk'
+        ],
+  ## uncomment this to disable apk upload
+      validate_only: true,
+      skip_upload_metadata: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true
+    )
+
+  end
+
   desc "Submit a new Release Build to Google Play Alpha channel"
   lane :alpha do
 
@@ -70,7 +93,6 @@ platform :android do
       skip_upload_screenshots: true  
     )
 
-    # You can also use other beta testing services here
   end
 
   # You can define as many lanes as you want

--- a/android/fastlane/README.md
+++ b/android/fastlane/README.md
@@ -26,6 +26,11 @@ Runs all the tests
 fastlane android local
 ```
 run a local debug build
+### android internal
+```
+fastlane android internal
+```
+Submit a new Release Build to Google Play Internal testing channel
 ### android alpha
 ```
 fastlane android alpha

--- a/ios/Gemfile.lock
+++ b/ios/Gemfile.lock
@@ -153,7 +153,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane (~> 2.95)
+  fastlane
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
This changeset shifts our default deployment channel to internal testing track instead of alpha track on google play.

The internal testing track allows insta-propagation of builds to QA devices