### PR TITLE
Upgrade rn-uport-signer

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "react-native-swiper": "^1.5.14",
     "react-native-tab-view": "^1.3.0",
     "react-native-touch-id": "^3.0.0",
-    "react-native-uport-signer": "^1.1.2",
+    "react-native-uport-signer": "1.3.2",
     "react-native-vector-icons": "^6.1.0",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7952,10 +7952,10 @@ react-native-typescript-transformer@^1.2.10:
     semver "^5.4.1"
     source-map "^0.5.6"
 
-react-native-uport-signer@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/react-native-uport-signer/-/react-native-uport-signer-1.1.2.tgz#5b204cd27f4c025185228a7f4333feb0c6c0f26e"
-  integrity sha512-UHc9TcyhP8YlZr726vfsfrFZGqIu0ocP68Sd2CeKY1x3Xg7TZjvfocx4Ohg+B4GgNRAAFnM5g8Zfn449cWJ8ew==
+react-native-uport-signer@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/react-native-uport-signer/-/react-native-uport-signer-1.3.2.tgz#93aaccb355e83b328970fc8c31c1a8a9ea71a1f6"
+  integrity sha512-kbiIJIaA9qL1kDMqJI4nM0+x8MRrgXfDjSjnksbnbpELa3WkIEdqBckA0u/nCgEXi0uyx1ytR0YzCLL1W/gOig==
 
 react-native-vector-icons@^6.1.0:
   version "6.3.0"


### PR DESCRIPTION
upgrades to version 1.3.2 which contains the listSeedAddress method required for migration

app runs fine and tests pass for me locally but @pelle reported he was having issues when trying to do the upgrade himself. 

@simonas-notcat @jasonhealy @mirceanis @pelle please test to see if you can recreate any issues Pelle reported 