### PR TITLE
[Support] Fix android failed build on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,23 +90,23 @@ jobs:
             - ~/.bundle
       - restore_cache:
           keys:
-            - android-{{ arch }}-v3-{{ checksum "build.gradle" }}
-            - android-{{ arch }}-v3
+            - android-{{ arch }}-v4-{{ checksum "build.gradle" }}
+            - android-{{ arch }}-v4
       - run:
           name: get android dependencies
-          command: ./gradlew androidDependencies
+          command: ./gradlew :app:dependencies androidDependencies --no-parallel --no-daemon
       - save_cache:
-          key: android-{{ arch }}-v3-{{ checksum "build.gradle" }}
+          key: android-{{ arch }}-v4-{{ checksum "build.gradle" }}
           paths:
             - .gradle
             - ~/.gradle
 
       - run: PATH=$PATH:$HOME/vault && bash ../scripts/pull_google_services.sh
-      - run: ./gradlew :app:deliverArchives -x bundleReleaseJsAndAssets --no-parallel
+      - run: ./gradlew :app:deliverArchives -x bundleReleaseJsAndAssets --no-parallel --no-daemon
 
       - run:
           name: tests
-          command: cd ~/uport-mobile/android && ./gradlew :app:lint :app:test -x bundleReleaseJsAndAssets
+          command: cd ~/uport-mobile/android && ./gradlew :app:lint :app:test -x bundleReleaseJsAndAssets --no-parallel --no-daemon
 
       - persist_to_workspace:
           root: ~/uport-mobile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
             - ~/.gradle
 
       - run: PATH=$PATH:$HOME/vault && bash ../scripts/pull_google_services.sh
-      - run: ./gradlew :app:deliverArchives -x bundleReleaseJsAndAssets
+      - run: ./gradlew :app:deliverArchives -x bundleReleaseJsAndAssets --no-parallel
 
       - run:
           name: tests


### PR DESCRIPTION
This PR should fix the intermittent issues with the android build that have been "recently" appeared on circleci.
The trade-off is slower builds but that should not matter so much on CI, especially since the iOS step is much slower