### PR TITLE
Fix restoration of migrated identities

### DIFF
--- a/lib/sagas/__tests__/hubSaga-test.js
+++ b/lib/sagas/__tests__/hubSaga-test.js
@@ -25,7 +25,7 @@ import {
   saveMessage, startWorking, completeProcess, failProcess
 } from 'uPortMobile/lib/actions/processStatusActions'
 
-import { createToken } from 'uPortMobile/lib/sagas/jwt'
+import { createToken, createTokenWithRoot } from 'uPortMobile/lib/sagas/jwt'
 import { encryptEvent, decryptEvent } from 'uPortMobile/lib/sagas/encryption'
 import { currentAddress, hasPublishedDID } from 'uPortMobile/lib/selectors/identities'
 import { connected, waitUntilConnected } from '../networkState'
@@ -39,16 +39,19 @@ import { dataBackup } from 'uPortMobile/lib/selectors/settings'
 
 jest.mock('../jwt', () => {
   return {
-    createToken: () => Promise.resolve()
+    createToken: () => Promise.resolve(),
+    createTokenWithRoot: () => Promise.resolve()
   }
 })
 global.fetch = jest.fn(() => undefined)
 
-import hubSaga, { addToQueue, sendEvent, performCatchup, sendQueuedEvents, backupUrl, restoreUrl, maybeSnapShot, pollForEvents } from '../hubSaga'
+import hubSaga, { addToQueue, sendEvent, performCatchup, sendQueuedEvents, backupUrl, restoreUrl, maybeSnapShot, pollForEvents, checkForBackup } from '../hubSaga'
 import { decryptMessage } from '../encryption'
 import { STORE_IDENTITY } from '../../constants/UportActionTypes';
 
-const address = '34wjsxwvduano7NFC8ujNJnFjbacgYeWA8m'
+const networkAddress = '0x9df0e9759b17f34e9123adbe6d3f25d54b72ad6a'
+const address = `did:ethr:${networkAddress}`
+
 const event = {
   type: 'ADD_OWN_CLAIMS',
   address,
@@ -316,6 +319,65 @@ describe('performCatchup', () => {
         [select(hubHead), previous],
         [call(createToken, address, {previous}, 'Sign event'), bearerToken],
         [call(fetch, restoreUrl, request), throwError(new Error('Bad Connection'))]
+      ])
+      .call(fetch, restoreUrl, request)
+      .put(failProcess('sync', 'Bad Connection'))
+      .returns(false)
+      .run()
+  })
+})
+
+describe('checkForBackup', () => {
+  const bearerToken = 'JWT-PUSH'
+  const request = {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${bearerToken}`
+    }
+  }
+
+  it('call server successfully', () => {
+    const res = {
+      status: 'success',
+      data: { events: [{ event: encrypted, hash: next }], total: 1 }
+    }
+    const response = { json: () => res, status: 200 }
+    return expectSaga(checkForBackup, networkAddress)
+      .provide([
+        [call(waitUntilConnected), undefined],
+        [call(createTokenWithRoot, networkAddress, { previous: null }, 'Sign event'), bearerToken],
+        [call(fetch, restoreUrl, request), response]
+      ])
+      .call(fetch, restoreUrl, request)
+      .returns(true)
+      .run()
+  })
+
+  it('http error', () => {
+    const res = { message: 'internal error' }
+    const response = { json: () => res, status: 500 }
+    return expectSaga(checkForBackup, networkAddress)
+      .provide([
+        [call(waitUntilConnected), undefined],
+        [call(createTokenWithRoot, networkAddress, { previous: null }, 'Sign event'), bearerToken],
+        [call(fetch, restoreUrl, request), response]
+      ])
+      .call(fetch, restoreUrl, request)
+      .returns(false)
+      .run()
+  })
+
+  it('non http error', () => {
+    return expectSaga(checkForBackup, networkAddress)
+      .provide([
+        [call(waitUntilConnected), undefined],
+        [call(createTokenWithRoot, networkAddress, { previous: null }, 'Sign event'), bearerToken],
+        [
+          call(fetch, restoreUrl, request),
+          throwError(new Error('Bad Connection'))
+        ]
       ])
       .call(fetch, restoreUrl, request)
       .put(failProcess('sync', 'Bad Connection'))

--- a/lib/sagas/__tests__/jwt-test.js
+++ b/lib/sagas/__tests__/jwt-test.js
@@ -54,13 +54,15 @@ jest.doMock('react-native', () => {
 import { currentAddress } from 'uPortMobile/lib/selectors/identities'
 import {
   createToken,
+  createTokenWithRoot,
   createShareResponseToken,
   credentialsFor,
   verifyToken,
   createShareRequestToken,
   createAttestationToken,
   createPututuAuthToken,
-  normalizeRecoveryParam
+  normalizeRecoveryParam,
+  credentialsForRoot
 } from '../jwt'
 import { decodeJWT } from 'did-jwt'
 import { TokenVerifier } from 'jsontokens'
@@ -145,6 +147,106 @@ describe('createToken', () => {
       ])
       .run()
       .then(result => expect(decodeJWT(result.returnValue).payload.iss).toEqual(did))
+  })
+})
+
+describe('createTokenWithRoot', () => {
+  it('sign jwt', () => {
+    return expectSaga(
+      createTokenWithRoot,
+      address,
+      { claims: { name: 'Bob' } },
+      { prompt: 'sign attestation', issuer: address }
+    )
+      .provide([
+        [
+          call(credentialsForRoot, address, 'sign attestation'),
+          credentials
+        ]
+      ])
+      .returns(
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTQwNzUzMywiY2xhaW1zIjp7Im5hbWUiOiJCb2IifSwiaXNzIjoiZGlkOnVwb3J0OjM0d2pzeHd2ZHVhbm83TkZDOHVqTkpuRmpiYWNnWWVXQThtIn0.QwgeiPOmQpqiAZMsY7KJPR6Je3olygRKaYbZ9g2zfTa-6a_mxAa6RUfzzIbdUCdMI8A6rYykrvZ1SQEr1XKrCA'
+      )
+      .run()
+      .then(result => expect(verifier.verify(result.returnValue)).toBeTruthy())
+  })
+
+  it('sign jwt without prompt', () => {
+    return expectSaga(
+      createTokenWithRoot,
+      address,
+      { claims: { name: 'Bob' } },
+      { issuer: address }
+    )
+      .provide([
+        [
+          call(credentialsForRoot, address, undefined),
+          credentials
+        ]
+      ])
+      .returns(
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTQwNzUzMywiY2xhaW1zIjp7Im5hbWUiOiJCb2IifSwiaXNzIjoiZGlkOnVwb3J0OjM0d2pzeHd2ZHVhbm83TkZDOHVqTkpuRmpiYWNnWWVXQThtIn0.QwgeiPOmQpqiAZMsY7KJPR6Je3olygRKaYbZ9g2zfTa-6a_mxAa6RUfzzIbdUCdMI8A6rYykrvZ1SQEr1XKrCA'
+      )
+      .run()
+      .then(result => expect(verifier.verify(result.returnValue)).toBeTruthy())
+  })
+
+  it('passes in expiration', () => {
+    return expectSaga(
+      createTokenWithRoot,
+      address,
+      { claims: { name: 'Bob' } },
+      { prompt: 'sign attestation', expiresIn: 86400, issuer: address }
+    )
+      .provide([
+        [
+          call(credentialsForRoot, address, 'sign attestation'),
+          credentials
+        ]
+      ])
+      .run()
+      .then(result =>
+        expect(decodeJWT(result.returnValue).payload.exp).toEqual(NOW + 86400)
+      )
+  })
+
+  it('override exp', () => {
+    const EXP = 2485321133
+    return expectSaga(
+      createTokenWithRoot,
+      address,
+      { claims: { name: 'Bob' }, exp: EXP },
+      { prompt: 'sign attestation', issuer: address }
+    )
+      .provide([
+        [
+          call(credentialsForRoot, address, 'sign attestation'),
+          credentials
+        ]
+      ])
+      .run()
+      .then(result =>
+        expect(decodeJWT(result.returnValue).payload.exp).toEqual(EXP)
+      )
+  })
+
+  it('uses correct issuer', () => {
+    return expectSaga(
+      createTokenWithRoot,
+      address,
+      { claims: { name: 'Bob' } },
+      { prompt: 'sign attestation', issuer: did }
+    )
+      .provide([
+        [
+          call(credentialsForRoot, address, 'sign attestation'),
+          credentials
+        ]
+      ])
+      .run()
+      .then(result =>
+        expect(decodeJWT(result.returnValue).payload.iss).toEqual(did)
+      )
   })
 })
 

--- a/lib/sagas/__tests__/recoverySaga-test.js
+++ b/lib/sagas/__tests__/recoverySaga-test.js
@@ -15,43 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with uPort Mobile App.  If not, see <http://www.gnu.org/licenses/>.
 //
-jest.mock('react-native-navigation', () => {
-  return {
-    Navigation: {},
-  }
-})
-jest.mock('../persona', () => {
-  return {
-    lookupUportHash: address => Promise.resolve('IPFS'),
-  }
-})
-jest.mock('react-native-uport-signer', () => {
-  return {
-    RNUportHDSigner: {
-      showSeed: async (address, message) => {
-        if (address !== '0x7f2d6bb19b6a52698725f4a292e985c51cefc315') throw new Error('Unsupported address')
-        return 'secret seed'
-      },
-      importSeed: async seed => {
-        return {
-          address: '0x7f2d6bb19b6a52698725f4a292e985c51cefc315',
-        }
-      },
-    },
-  }
-})
-
-jest.mock('react-native-navigation', () => {
-  return {
-    Navigation: {},
-  }
-})
-jest.mock('../persona', () => {
-  return {
-    lookupUportHash: address => Promise.resolve('IPFS'),
-  }
-})
-
 import { RNUportHDSigner } from 'react-native-uport-signer'
 import { call, select, spawn } from 'redux-saga/effects'
 import { expectSaga } from 'redux-saga-test-plan'
@@ -59,13 +22,27 @@ import * as matchers from 'redux-saga-test-plan/matchers'
 import { throwError } from 'redux-saga-test-plan/providers'
 
 import recoverySaga, { alert } from '../recoverySaga'
-import { importSeed, createRecoveryAddress, encryptionPublicKey, DEFAULT_LEVEL } from '../keychain'
+import { checkForBackup } from '../hubSaga'
+import {
+  importSeed,
+  createRecoveryAddress,
+  encryptionPublicKey,
+  DEFAULT_LEVEL
+} from '../keychain'
 import { lookupAccount } from '../unnu'
 import { hdRootAddress } from 'uPortMobile/lib/selectors/hdWallet'
 import authorize from 'uPortMobile/lib/helpers/authorize'
 
-import { showRecoverySeed, saveRecoverySeed, startSeedRecovery } from 'uPortMobile/lib/actions/recoveryActions'
-import { startWorking, completeProcess, failProcess } from 'uPortMobile/lib/actions/processStatusActions'
+import {
+  showRecoverySeed,
+  saveRecoverySeed,
+  startSeedRecovery
+} from 'uPortMobile/lib/actions/recoveryActions'
+import {
+  startWorking,
+  completeProcess,
+  failProcess
+} from 'uPortMobile/lib/actions/processStatusActions'
 
 import { storeIdentity } from 'uPortMobile/lib/actions/uportActions'
 import { seedConfirmed } from 'uPortMobile/lib/actions/HDWalletActions'
@@ -74,6 +51,42 @@ import { fetchAllSettings } from '../blockchain'
 import { lookupUportHash } from '../persona'
 import UportContracts from 'uport-identity'
 import { securityLevel } from 'uPortMobile/lib/selectors/chains'
+import { Navigation } from 'react-native-navigation'
+import SCREENS from 'uPortMobile/lib/screens/Screens'
+
+jest.mock('react-native-navigation', () => {
+  return {
+    Navigation: {
+      push: () => true
+    }
+  }
+})
+jest.mock('../persona', () => {
+  return {
+    lookupUportHash: address => Promise.resolve('IPFS')
+  }
+})
+jest.mock('react-native-uport-signer', () => {
+  return {
+    RNUportHDSigner: {
+      showSeed: async (address, message) => {
+        if (address !== '0x7f2d6bb19b6a52698725f4a292e985c51cefc315') { throw new Error('Unsupported address') }
+        return 'secret seed'
+      },
+      importSeed: async seed => {
+        return {
+          address: '0x7f2d6bb19b6a52698725f4a292e985c51cefc315'
+        }
+      }
+    }
+  }
+})
+
+jest.mock('../persona', () => {
+  return {
+    lookupUportHash: address => Promise.resolve('IPFS')
+  }
+})
 
 const MNID = require('mnid')
 const TxRelay = UportContracts.TxRelay.v2
@@ -82,7 +95,10 @@ const root = '0x7f2d6bb19b6a52698725f4a292e985c51cefc315'
 describe('SHOW_RECOVERY_SEED', () => {
   it('shows seed if user authorizes', () => {
     return expectSaga(recoverySaga)
-      .provide([[matchers.call.fn(authorize), true], [select(hdRootAddress), root]])
+      .provide([
+        [matchers.call.fn(authorize), true],
+        [select(hdRootAddress), root]
+      ])
       .call(RNUportHDSigner.showSeed, root, 'Show your current recovery seed?')
       .put(saveRecoverySeed('secret seed'))
       .dispatch(showRecoverySeed())
@@ -92,7 +108,11 @@ describe('SHOW_RECOVERY_SEED', () => {
   it('does not shows seed if user does not authorize', () => {
     return expectSaga(recoverySaga)
       .provide([[matchers.call.fn(authorize), false]])
-      .not.call(RNUportHDSigner.showSeed, root, 'Show your current recovery seed?')
+      .not.call(
+        RNUportHDSigner.showSeed,
+        root,
+        'Show your current recovery seed?'
+      )
       .not.put(saveRecoverySeed('secret seed'))
       .dispatch(showRecoverySeed())
       .run({ silenceTimeout: true })
@@ -104,6 +124,7 @@ describe('START_SEED_RECOVERY', () => {
   const deviceAddress = root
   const publicKey = '0x0401public'
   const publicEncKey = 'ENCRYPTION KEY'
+  const componentId = 'COMPONENT_ID'
 
   const kp = {
     deviceAddress,
@@ -114,47 +135,142 @@ describe('START_SEED_RECOVERY', () => {
     publicEncKey,
     own: { name: 'uPort User' },
     securityLevel: 'simple',
-    network: 'mainnet',
+    network: 'mainnet'
   }
 
   describe('ethr did identity', () => {
     describe('blank device', () => {
       it('is successful', () => {
-        return (
-          expectSaga(recoverySaga)
-            .provide([
-              [select(hdRootAddress), undefined],
-              [select(securityLevel), DEFAULT_LEVEL],
-              [call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL), { address: root }],
-              [call(importSeed, seed), kp],
-              [call(lookupAccount, { deviceAddress })],
-              [
-                call(alert, 'Recovery Successful!!!', {
-                  screen: 'recovery.seedSuccess',
-                  backButtonTitle: '',
-                  navigatorStyle: {
-                    navBarHidden: true,
-                  },
-                }),
-              ],
-            ])
-            .put(startWorking('recovery'))
-            .call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL)
-            .call(importSeed, seed)
-            .call(lookupAccount, { deviceAddress })
-            .put(storeIdentity(kp))
-            .put(seedConfirmed())
-            .put(completeProcess('recovery'))
-            // .call([Navigation, Navigation.push], {
-            //   screen: 'recovery.seedSuccess',
-            //   backButtonTitle: '',
-            //   navigatorStyle: {
-            //     navBarHidden: true,
-            //   },
-            // })
-            .dispatch(startSeedRecovery(seed))
-            .silentRun()
-        )
+        return expectSaga(recoverySaga)
+          .provide([
+            [select(hdRootAddress), undefined],
+            [select(securityLevel), DEFAULT_LEVEL],
+            [
+              call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL),
+              { address: root }
+            ],
+            [call(importSeed, seed), kp],
+            [call(checkForBackup, deviceAddress), true],
+            [call(lookupAccount, { deviceAddress })],
+            [
+              call(alert, 'Recovery Successful!!!', {
+                screen: 'recovery.seedSuccess',
+                backButtonTitle: '',
+                navigatorStyle: {
+                  navBarHidden: true
+                }
+              })
+            ]
+          ])
+          .put(startWorking('recovery'))
+          .call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL)
+          .call(importSeed, seed)
+          .put(storeIdentity(kp))
+          .put(seedConfirmed())
+          .put(completeProcess('recovery'))
+          .call([Navigation, Navigation.push], componentId, {
+            component: {
+              name: SCREENS.RECOVERY.RestoreSeedSuccess,
+              options: {
+                topBar: {
+                  visible: false
+                }
+              }
+            }
+          })
+          .dispatch(startSeedRecovery(seed, componentId))
+          .silentRun()
+      })
+    })
+  })
+
+  describe('unbacked up did identity', () => {
+    describe('blank device', () => {
+      it('is successful', () => {
+        return expectSaga(recoverySaga)
+          .provide([
+            [select(hdRootAddress), undefined],
+            [select(securityLevel), DEFAULT_LEVEL],
+            [
+              call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL),
+              { address: root }
+            ],
+            [call(importSeed, seed), kp],
+            [call(checkForBackup, deviceAddress), false],
+            [call(lookupAccount, { deviceAddress })],
+            [
+              call(alert, 'Recovery Successful!!!', {
+                screen: 'recovery.seedSuccess',
+                backButtonTitle: '',
+                navigatorStyle: {
+                  navBarHidden: true
+                }
+              })
+            ]
+          ])
+          .put(startWorking('recovery'))
+          .call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL)
+          .call(importSeed, seed)
+          .put(storeIdentity(kp))
+          .put(seedConfirmed())
+          .put(completeProcess('recovery'))
+          .call([Navigation, Navigation.push], componentId, {
+            component: {
+              name: SCREENS.RECOVERY.RestoreSeedSuccess,
+              options: {
+                topBar: {
+                  visible: false
+                }
+              }
+            }
+          })
+          .dispatch(startSeedRecovery(seed, componentId))
+          .silentRun()
+      })
+    })
+  })
+
+  describe('migrated identity', () => {
+    describe('blank device', () => {
+      it('is successful', () => {
+        return expectSaga(recoverySaga)
+          .provide([
+            [select(hdRootAddress), undefined],
+            [select(securityLevel), DEFAULT_LEVEL],
+            [
+              call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL),
+              { address: root }
+            ],
+            [call(importSeed, seed), kp],
+            [call(checkForBackup, deviceAddress), true],
+            [
+              call(alert, 'Recovery Successful!!!', {
+                screen: 'recovery.seedSuccess',
+                backButtonTitle: '',
+                navigatorStyle: {
+                  navBarHidden: true
+                }
+              })
+            ]
+          ])
+          .put(startWorking('recovery'))
+          .call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL)
+          .call(importSeed, seed)
+          .put(storeIdentity(kp))
+          .put(seedConfirmed())
+          .put(completeProcess('recovery'))
+          .call([Navigation, Navigation.push], componentId, {
+            component: {
+              name: SCREENS.RECOVERY.RestoreSeedSuccess,
+              options: {
+                topBar: {
+                  visible: false
+                }
+              }
+            }
+          })
+          .dispatch(startSeedRecovery(seed, componentId))
+          .silentRun()
       })
     })
   })
@@ -174,93 +290,117 @@ describe('START_SEED_RECOVERY', () => {
       controllerAddress: managerAddress,
       signerType: managerType,
       hexaddress,
-      txRelayAddress: TxRelay.networks[4].address,
+      txRelayAddress: TxRelay.networks[4].address
     }
     it('is successful ', () => {
-      return (
-        expectSaga(recoverySaga)
-          .provide([
-            [select(securityLevel), DEFAULT_LEVEL],
-            [call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL), { address: root }],
-            [call(importSeed, seed), kp],
-            [select(hdRootAddress), undefined],
-            [call(lookupAccount, { deviceAddress }), identity],
-            [call(createRecoveryAddress, 0), recoveryAddress],
-            [call(encryptionPublicKey, { idIndex: 0, actIndex: 0 }), publicEncKey],
-            [call(lookupUportHash, address), ipfsProfile],
-            [spawn(fetchAllSettings, { address }), undefined],
-            // [
-            //   call(Navigation.showModal, {
-            //     component: {},
-            //   }),
-            // ],
-          ])
-          .put(startWorking('recovery'))
-          .call(importSeed, seed)
-          .call(lookupAccount, { deviceAddress })
-          .call(createRecoveryAddress, 0)
-          .put(
-            storeIdentity({
-              ...identity,
-              deviceAddress,
-              recoveryAddress,
-              publicEncKey,
-              hdindex: 0,
-              ipfsProfile,
-              own: { name: 'uPort User' },
-              publicKey: publicKey,
-              securityLevel: DEFAULT_LEVEL,
-            }),
-          )
-          .put(seedConfirmed())
-          .put(completeProcess('recovery'))
-          // .call(Navigation.showModal, {
-          //   component: {},
-          // })
-          .dispatch(startSeedRecovery(seed))
-          .silentRun()
-      )
+      return expectSaga(recoverySaga)
+        .provide([
+          [select(securityLevel), DEFAULT_LEVEL],
+          [
+            call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL),
+            { address: root }
+          ],
+          [call(importSeed, seed), kp],
+          [select(hdRootAddress), undefined],
+          [call(lookupAccount, { deviceAddress }), identity],
+          [call(createRecoveryAddress, 0), recoveryAddress],
+          [
+            call(encryptionPublicKey, { idIndex: 0, actIndex: 0 }),
+            publicEncKey
+          ],
+          [call(checkForBackup, deviceAddress), false],
+          [call(lookupUportHash, address), ipfsProfile],
+          [spawn(fetchAllSettings, { address }), undefined]
+        ])
+        .put(startWorking('recovery'))
+        .call(importSeed, seed)
+        .call(lookupAccount, { deviceAddress })
+        .call(createRecoveryAddress, 0)
+        .put(
+          storeIdentity({
+            ...identity,
+            deviceAddress,
+            recoveryAddress,
+            publicEncKey,
+            hdindex: 0,
+            ipfsProfile,
+            own: { name: 'uPort User' },
+            publicKey: publicKey,
+            securityLevel: DEFAULT_LEVEL
+          })
+        )
+        .put(seedConfirmed())
+        .put(completeProcess('recovery'))
+        .call([Navigation, Navigation.push], componentId, {
+          component: {
+            name: SCREENS.RECOVERY.RestoreSeedSuccess,
+            options: {
+              topBar: {
+                visible: false
+              }
+            }
+          }
+        })
+        .dispatch(startSeedRecovery(seed, componentId))
+        .silentRun()
     })
   })
 
   describe('restored state missing seed', () => {
     it('is successful', () => {
-      return (
-        expectSaga(recoverySaga)
-          .provide([
-            [select(securityLevel), DEFAULT_LEVEL],
-            [call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL), { address: root }],
-            [select(hdRootAddress), deviceAddress],
-            // [
-            //   call(Navigation.showModal, {
-            //     component: {},
-            //   }),
-            // ],
-          ])
-          .put(startWorking('recovery'))
-          .call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL)
-          .not.call(lookupAccount, { deviceAddress })
-          .not.put(storeIdentity(kp))
-          .put(seedConfirmed())
-          .put(completeProcess('recovery'))
-          // .call(Navigation.showModal, {
-          //   component: {},
-          // })
-          .dispatch(startSeedRecovery(seed))
-          .silentRun()
-      )
+      return expectSaga(recoverySaga)
+        .provide([
+          [select(securityLevel), DEFAULT_LEVEL],
+          [
+            call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL),
+            { address: root }
+          ],
+          [select(hdRootAddress), deviceAddress]
+          // [
+          //   call(Navigation.showModal, {
+          //     component: {},
+          //   }),
+          // ],
+        ])
+        .put(startWorking('recovery'))
+        .call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL)
+        .not.call(checkForBackup, deviceAddress)
+        .not.call(lookupAccount, { deviceAddress })
+        .not.put(storeIdentity(kp))
+        .put(seedConfirmed())
+        .put(completeProcess('recovery'))
+        .call([Navigation, Navigation.push], componentId, {
+          component: {
+            name: SCREENS.RECOVERY.RestoreSeedSuccess,
+            options: {
+              topBar: {
+                visible: false
+              }
+            }
+          }
+        })
+        .dispatch(startSeedRecovery(seed, componentId))
+        .silentRun()
     })
 
     it('working but incorrect seed', () => {
       return expectSaga(recoverySaga)
         .provide([
           [select(securityLevel), DEFAULT_LEVEL],
-          [call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL), { address: root }],
-          [select(hdRootAddress), '0xother'],
+          [
+            call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL),
+            { address: root }
+          ],
+          [select(hdRootAddress), '0xother']
         ])
         .put(startWorking('recovery'))
         .call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL)
-        .put(failProcess('recovery', 'Seed does not match the Identity stored on your Phone'))
+        .put(
+          failProcess(
+            'recovery',
+            'Seed does not match the Identity stored on your Phone'
+          )
+        )
         .dispatch(startSeedRecovery(seed))
         .silentRun()
     })
@@ -271,7 +411,7 @@ describe('START_SEED_RECOVERY', () => {
       return expectSaga(recoverySaga)
         .provide([
           [select(securityLevel), DEFAULT_LEVEL],
-          [call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL), undefined],
+          [call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL), undefined]
         ])
         .put(startWorking('recovery'))
         .call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL)
@@ -284,10 +424,17 @@ describe('START_SEED_RECOVERY', () => {
       return expectSaga(recoverySaga)
         .provide([
           [select(securityLevel), DEFAULT_LEVEL],
-          [call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL), { address: root }],
+          [
+            call(RNUportHDSigner.importSeed, seed, DEFAULT_LEVEL),
+            { address: root }
+          ],
           [call(importSeed, seed), kp],
           [select(hdRootAddress), undefined],
-          [call(lookupAccount, { deviceAddress }), throwError(new Error('Bad Connection'))],
+          [call(checkForBackup, deviceAddress), false],
+          [
+            call(lookupAccount, { deviceAddress }),
+            throwError(new Error('Bad Connection'))
+          ]
         ])
         .put(startWorking('recovery'))
         .call(importSeed, seed)

--- a/lib/sagas/hubSaga.js
+++ b/lib/sagas/hubSaga.js
@@ -38,7 +38,7 @@ import * as vcActions from 'uPortMobile/lib/actions/vcActions'
 import { saveMessage, startWorking, completeProcess, failProcess } from 'uPortMobile/lib/actions/processStatusActions'
 
 import { waitUntilConnected } from './networkState'
-import { createToken, verifyToken } from 'uPortMobile/lib/sagas/jwt'
+import { createToken, createTokenWithRoot, verifyToken } from 'uPortMobile/lib/sagas/jwt'
 import { encryptEvent, decryptEvent } from 'uPortMobile/lib/sagas/encryption'
 import { currentAddress, hasPublishedDID } from 'uPortMobile/lib/selectors/identities'
 import { hubHead, nextEvent, hubCanQueue, snapshot } from 'uPortMobile/lib/selectors/hubs'
@@ -124,7 +124,7 @@ export function* sendEvent(event) {
   }
 }
 
-export function* performCatchup() {
+export function* performCatchup () {
   // console.log('performCatchup')
   try {
     yield call(waitUntilConnected)
@@ -175,6 +175,34 @@ export function* performCatchup() {
     }
   } catch (error) {
     // console.log('performCatchup', error)
+    yield put(failProcess('sync', error.message))
+    return false
+  }
+}
+
+export function * checkForBackup (address) {
+  try {
+    yield call(waitUntilConnected)
+    yield put(startWorking('sync'))
+    yield put(saveMessage('sync', 'Checking if backup exists'))
+    const token = yield call(createTokenWithRoot, address, {previous: null}, 'Sign event')
+    const response = yield call(fetch, restoreUrl, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      }
+    })
+    yield put(saveMessage('sync', 'Checking if backup exists'))
+    yield put(completeProcess('sync'))
+    if (response.status === 200) {
+      return true
+    } else {
+      return false
+    }
+  } catch (error) {
+    // console.log('checkForBackup', error)
     yield put(failProcess('sync', error.message))
     return false
   }

--- a/lib/sagas/jwt.js
+++ b/lib/sagas/jwt.js
@@ -16,7 +16,6 @@
 // along with uPort Mobile App.  If not, see <http://www.gnu.org/licenses/>.
 //
 import { call, select } from 'redux-saga/effects'
-import { NativeModules } from 'react-native'
 import { verifyJWT } from 'did-jwt'
 import { Credentials } from 'uport-credentials'
 import { deviceAddressForAddress } from 'uPortMobile/lib/selectors/chains'
@@ -85,6 +84,29 @@ export function * credentialsFor (address, prompt, opts = {}) {
 
 export function * createToken (address, payload, opts = {}) {
   const credentials = yield call(credentialsFor, address, opts.prompt, { issuer: opts.issuer })
+  return yield call([credentials, credentials.signJWT], payload, typeof opts.expiresIn === 'undefined' ? DAY : opts.expiresIn)
+}
+
+export function * credentialsForRoot (address, prompt) {
+  const signJwt = partial(RNUportHDSigner.signJwt, address, `m/7696500'/0'/0'/0'`)
+  const signer = async data => {
+    const { v, r, s } = await signJwt(
+      Buffer.from(data).toString('base64'),
+      prompt || 'sign request'
+    )
+    return {
+      recoveryParam: normalizeRecoveryParam(v),
+      r: Buffer.from(r, 'base64').toString('hex'),
+      s: Buffer.from(s, 'base64').toString('hex')
+    }
+  }
+
+  return new Credentials({signer, did: `did:ethr:${address}`})
+}
+
+// This is used for signing a JWT during recovery, when the datamodel is not fully recovered yet
+export function * createTokenWithRoot (address, payload, opts = {}) {
+  const credentials = yield call(credentialsForRoot, address, opts.prompt)
   return yield call([credentials, credentials.signJWT], payload, typeof opts.expiresIn === 'undefined' ? DAY : opts.expiresIn)
 }
 

--- a/lib/sagas/migrations/MigrateLegacy.ts
+++ b/lib/sagas/migrations/MigrateLegacy.ts
@@ -148,9 +148,7 @@ export function* migrate(): any {
     )
   }
   yield put(saveMessage(step, 'New mainnet identity is created'))
-  if (backedup) {
-    yield call(handleStartSwitchingSettingsChange, { isOn: true })
-  }
+  yield call(handleStartSwitchingSettingsChange, { isOn: true })
   return true
 }
 

--- a/lib/sagas/migrations/__tests__/MigrateLegacy-test.ts
+++ b/lib/sagas/migrations/__tests__/MigrateLegacy-test.ts
@@ -96,6 +96,7 @@ describe('MigrateLegacy', () => {
                 [select(hasAttestations), false],
                 [select(hasMainnetAccounts), false],
                 [select(subAccounts, legacyDID), []],
+                [call(handleStartSwitchingSettingsChange, { isOn: true }), undefined]
               ])
               .put(
                 storeIdentity({
@@ -119,6 +120,7 @@ describe('MigrateLegacy', () => {
                 }),
               )
               .put(saveMessage(step, 'New mainnet identity is created'))
+              .call(handleStartSwitchingSettingsChange, { isOn: true })
               .returns(true)
               .run()
           })
@@ -142,6 +144,7 @@ describe('MigrateLegacy', () => {
                     [call(canSignFor, 'account1'), true],
                     [call(canSignFor, 'account2'), true],
                     [call(canSignFor, 'account3'), true],
+                    [call(handleStartSwitchingSettingsChange, { isOn: true }), undefined]
                   ])
                   .put(
                     storeIdentity({
@@ -165,6 +168,7 @@ describe('MigrateLegacy', () => {
                     }),
                   )
                   .put(saveMessage(step, 'New mainnet identity is created'))
+                  .call(handleStartSwitchingSettingsChange, { isOn: true })
                   .returns(true)
                   .run()
               })
@@ -188,6 +192,7 @@ describe('MigrateLegacy', () => {
                     [call(canSignFor, 'account1'), false],
                     [call(canSignFor, 'account2'), false],
                     [call(canSignFor, 'account3'), true],
+                    [call(handleStartSwitchingSettingsChange, { isOn: true }), undefined]
                   ])
                   .put(
                     storeIdentity({
@@ -223,6 +228,7 @@ describe('MigrateLegacy', () => {
                     }),
                   )
                   .put(saveMessage(step, 'New mainnet identity is created'))
+                  .call(handleStartSwitchingSettingsChange, { isOn: true })
                   .returns(true)
                   .run()
               })
@@ -246,6 +252,7 @@ describe('MigrateLegacy', () => {
                 [call(createIdentityKeyPair), { address: newDID }],
                 [select(ownClaimsMap), own],
                 [select(subAccounts, legacyDID), []],
+                [call(handleStartSwitchingSettingsChange, { isOn: true }), undefined]
               ])
               .put(resetHDWallet())
               .call(createIdentityKeyPair)
@@ -257,6 +264,7 @@ describe('MigrateLegacy', () => {
                 }),
               )
               .put(saveMessage(step, 'New mainnet identity is created'))
+              .call(handleStartSwitchingSettingsChange, { isOn: true })
               .returns(true)
               .run()
           })
@@ -276,6 +284,7 @@ describe('MigrateLegacy', () => {
                 [call(createIdentityKeyPair), { address: newDID }],
                 [select(ownClaimsMap), own],
                 [select(subAccounts, legacyDID), []],
+                [call(handleStartSwitchingSettingsChange, { isOn: true }), undefined]
               ])
               .call(createIdentityKeyPair)
               .put(updateIdentity(newDID, { own }))
@@ -286,6 +295,7 @@ describe('MigrateLegacy', () => {
                 }),
               )
               .put(saveMessage(step, 'New mainnet identity is created'))
+              .call(handleStartSwitchingSettingsChange, { isOn: true })
               .returns(true)
               .run()
           })
@@ -308,6 +318,7 @@ describe('MigrateLegacy', () => {
                     [call(canSignFor, 'account1'), true],
                     [call(canSignFor, 'account2'), true],
                     [call(canSignFor, 'account3'), true],
+                    [call(handleStartSwitchingSettingsChange, { isOn: true }), undefined]
                   ])
                   .call(createIdentityKeyPair)
                   .put(updateIdentity(newDID, { own }))
@@ -318,6 +329,7 @@ describe('MigrateLegacy', () => {
                     }),
                   )
                   .put(saveMessage(step, 'New mainnet identity is created'))
+                  .call(handleStartSwitchingSettingsChange, { isOn: true })
                   .returns(true)
                   .run()
               })
@@ -341,6 +353,7 @@ describe('MigrateLegacy', () => {
                     [call(canSignFor, 'account1'), false],
                     [call(canSignFor, 'account2'), false],
                     [call(canSignFor, 'account3'), true],
+                    [call(handleStartSwitchingSettingsChange, { isOn: true }), undefined]
                   ])
                   .call(createIdentityKeyPair)
                   .put(updateIdentity(newDID, { own }))
@@ -363,6 +376,7 @@ describe('MigrateLegacy', () => {
                     }),
                   )
                   .put(saveMessage(step, 'New mainnet identity is created'))
+                  .call(handleStartSwitchingSettingsChange, { isOn: true })
                   .returns(true)
                   .run()
               })
@@ -390,6 +404,7 @@ describe('MigrateLegacy', () => {
               [call(encryptionPublicKey, { idIndex: 0, actIndex: 0 }), encPublicKey],
               [select(ownClaimsMap), own],
               [select(subAccounts, legacyDID), []],
+              [call(handleStartSwitchingSettingsChange, { isOn: true }), undefined]
             ])
             .put(
               storeIdentity({
@@ -407,6 +422,7 @@ describe('MigrateLegacy', () => {
               }),
             )
             .put(saveMessage(step, 'New mainnet identity is created'))
+            .call(handleStartSwitchingSettingsChange, { isOn: true })
             .returns(true)
             .run()
         })
@@ -469,6 +485,7 @@ describe('MigrateLegacy', () => {
                 [call(encryptionPublicKey, { idIndex: 0, actIndex: 0 }), encPublicKey],
                 [select(ownClaimsMap), own],
                 [select(subAccounts, legacyDID), []],
+                [call(handleStartSwitchingSettingsChange, { isOn: true }), undefined]
               ])
               .put(
                 storeIdentity({
@@ -490,6 +507,7 @@ describe('MigrateLegacy', () => {
               .put(storeExternalUport(legacyDID, own))
               .put(storeConnection(newDID, 'knows', legacyDID))
               .put(saveMessage(step, 'New mainnet identity is created'))
+              .call(handleStartSwitchingSettingsChange, { isOn: true })
               .returns(true)
               .run()
           })  
@@ -512,6 +530,7 @@ describe('MigrateLegacy', () => {
                 [call(encryptionPublicKey, { idIndex: 0, actIndex: 0 }), encPublicKey],
                 [select(ownClaimsMap), own],
                 [select(subAccounts, legacyDID), []],
+                [call(handleStartSwitchingSettingsChange, { isOn: true }), undefined]
               ])
               .put(
                 storeIdentity({
@@ -533,6 +552,7 @@ describe('MigrateLegacy', () => {
               .put(storeExternalUport(legacyDID, own))
               .put(storeConnection(newDID, 'knows', legacyDID))
               .put(saveMessage(step, 'New mainnet identity is created'))
+              .call(handleStartSwitchingSettingsChange, { isOn: true })
               .returns(true)
               .run()
           })
@@ -558,6 +578,7 @@ describe('MigrateLegacy', () => {
                   [call(canSignFor, 'account1'), true],
                   [call(canSignFor, 'account2'), true],
                   [call(canSignFor, 'account3'), true],
+                  [call(handleStartSwitchingSettingsChange, { isOn: true }), undefined]
                 ])
                 .put(
                   storeIdentity({
@@ -575,6 +596,7 @@ describe('MigrateLegacy', () => {
                   }),
                 )
                 .put(saveMessage(step, 'New mainnet identity is created'))
+                .call(handleStartSwitchingSettingsChange, { isOn: true })
                 .returns(true)
                 .run()
             })
@@ -598,6 +620,7 @@ describe('MigrateLegacy', () => {
                   [call(canSignFor, 'account1'), false],
                   [call(canSignFor, 'account2'), false],
                   [call(canSignFor, 'account3'), true],
+                  [call(handleStartSwitchingSettingsChange, { isOn: true }), undefined]
                 ])
                 .put(
                   storeIdentity({
@@ -628,6 +651,7 @@ describe('MigrateLegacy', () => {
                 )
                 .put(saveMessage(step, 'New mainnet identity is created'))
                 .returns(true)
+                .call(handleStartSwitchingSettingsChange, { isOn: true })
                 .run()
             })
           })
@@ -650,12 +674,14 @@ describe('MigrateLegacy', () => {
               [call(createIdentityKeyPair), { address: newDID }],
               [select(ownClaimsMap), own],
               [select(subAccounts, legacyDID), []],
+              [call(handleStartSwitchingSettingsChange, { isOn: true }), undefined]
             ])
             .put(resetHDWallet())
             .call(createIdentityKeyPair)
             .put(updateIdentity(newDID, { own }))
             .put(saveMessage(step, 'New mainnet identity is created'))
             .returns(true)
+            .call(handleStartSwitchingSettingsChange, { isOn: true })
             .run()
         })
       })
@@ -674,11 +700,13 @@ describe('MigrateLegacy', () => {
               [call(createIdentityKeyPair), { address: newDID }],
               [select(ownClaimsMap), own],
               [select(subAccounts, legacyDID), []],
+              [call(handleStartSwitchingSettingsChange, { isOn: true }), undefined]
             ])
             .call(createIdentityKeyPair)
             .put(updateIdentity(newDID, { own }))
             .put(saveMessage(step, 'New mainnet identity is created'))
             .returns(true)
+            .call(handleStartSwitchingSettingsChange, { isOn: true })
             .run()
         })
       })

--- a/lib/sagas/persona.js
+++ b/lib/sagas/persona.js
@@ -149,7 +149,7 @@ export function * fetchPublicUport (address) {
       // console.log(`unable to resolve ${address}`)
     }
   } catch (error) {
-    console.log(`error in resolving did document for ${address}`)
+    // console.log(`error in resolving did document for ${address}`)
     // console.log(error)
   }
 }
@@ -205,10 +205,10 @@ export function * savePublicUport ({address, force}) {
       const request = yield call(handleURL, {url: setUportUrl(address, hexhash), postback: false, popup: false})
       // console.log(request)
       const {tx} = yield call(signTransaction, request)
-      console.log(tx)
+      // console.log(tx)
       const web3 = yield select(web3ForAddress, address)
       const receipt = yield call(waitForTransactionReceipt, web3, tx)
-      console.log('persona receipt', receipt)
+      // console.log('persona receipt', receipt)
       if (receipt) {
         yield put(saveIpfsProfile(address, ipfsHash))
         yield put(completeProcess('persona'))

--- a/lib/sagas/recoverySaga.js
+++ b/lib/sagas/recoverySaga.js
@@ -15,16 +15,31 @@
 // You should have received a copy of the GNU General Public License
 // along with uPort Mobile App.  If not, see <http://www.gnu.org/licenses/>.
 //
-import { takeEvery, call, select, put, all, take, spawn } from 'redux-saga/effects'
+import {
+  takeEvery,
+  call,
+  select,
+  put,
+  all,
+  take,
+  spawn
+} from 'redux-saga/effects'
 import { delay } from 'redux-saga'
 import { hdRootAddress } from 'uPortMobile/lib/selectors/hdWallet'
-import { SHOW_RECOVERY_SEED, START_SEED_RECOVERY } from 'uPortMobile/lib/constants/RecoveryActionTypes'
+import {
+  SHOW_RECOVERY_SEED,
+  START_SEED_RECOVERY
+} from 'uPortMobile/lib/constants/RecoveryActionTypes'
 import { NativeModules, Alert } from 'react-native'
 import { saveRecoverySeed } from 'uPortMobile/lib/actions/recoveryActions'
 import { storeIdentity } from 'uPortMobile/lib/actions/uportActions'
-import { startWorking, completeProcess, failProcess } from 'uPortMobile/lib/actions/processStatusActions'
+import {
+  startWorking,
+  completeProcess,
+  failProcess
+} from 'uPortMobile/lib/actions/processStatusActions'
 import { seedConfirmed } from 'uPortMobile/lib/actions/HDWalletActions'
-import { performCatchup } from 'uPortMobile/lib/sagas/hubSaga'
+import { performCatchup, checkForBackup } from 'uPortMobile/lib/sagas/hubSaga'
 import authorize from 'uPortMobile/lib/helpers/authorize'
 import { importSeed, createRecoveryAddress, DEFAULT_LEVEL } from './keychain'
 import { lookupAccount } from './unnu'
@@ -34,13 +49,17 @@ import { securityLevel } from '../selectors/chains'
 import { Navigation } from 'react-native-navigation'
 import SCREENS from '../screens/Screens'
 
-function* showSeed() {
+function * showSeed () {
   try {
     const authorized = yield call(authorize, 'Show your current recovery seed?')
     if (authorized) {
       const root = yield select(hdRootAddress)
       if (root) {
-        const seed = yield call(RNUportHDSigner.showSeed, root, 'Show your current recovery seed?')
+        const seed = yield call(
+          RNUportHDSigner.showSeed,
+          root,
+          'Show your current recovery seed?'
+        )
         if (seed) {
           yield put(saveRecoverySeed(seed))
         }
@@ -50,12 +69,17 @@ function* showSeed() {
     console.log(error)
   }
 }
-export function* alert(title, message) {
+export function * alert (title, message) {
   yield call(delay, 500)
   yield call([Alert, Alert.alert], title, message)
 }
 
-export function* performSeedRecovery({ phrase, componentId }) {
+function * isLegacy (deviceAddress) {
+  if (yield call(checkForBackup, deviceAddress)) return false
+  return yield call(lookupAccount, { deviceAddress })
+}
+
+export function * performSeedRecovery ({ phrase, componentId }) {
   try {
     yield put(startWorking('recovery'))
     const level = yield select(securityLevel)
@@ -68,13 +92,18 @@ export function* performSeedRecovery({ phrase, componentId }) {
     const existingRoot = yield select(hdRootAddress)
     if (existingRoot) {
       if (kp.address !== existingRoot) {
-        yield put(failProcess('recovery', 'Seed does not match the Identity stored on your Phone'))
+        yield put(
+          failProcess(
+            'recovery',
+            'Seed does not match the Identity stored on your Phone'
+          )
+        )
         return false
       }
     } else {
       const id = yield call(importSeed, phrase)
       const deviceAddress = id.deviceAddress
-      const legacy = yield call(lookupAccount, { deviceAddress })
+      const legacy = yield call(isLegacy, deviceAddress)
       if (legacy) {
         const ipfsProfile = yield call(lookupUportHash, legacy.address)
         const recoveryAddress = yield call(createRecoveryAddress, 0)
@@ -85,8 +114,8 @@ export function* performSeedRecovery({ phrase, componentId }) {
             ipfsProfile,
             recoveryAddress,
             network: 'rinkeby',
-            securityLevel: DEFAULT_LEVEL,
-          }),
+            securityLevel: DEFAULT_LEVEL
+          })
         )
       } else {
         yield put(storeIdentity({ ...id, securityLevel: DEFAULT_LEVEL }))
@@ -95,16 +124,15 @@ export function* performSeedRecovery({ phrase, componentId }) {
     }
     yield put(seedConfirmed())
     yield put(completeProcess('recovery'))
-    yield call([Navigation, Navigation.push], 
-      componentId, {
+    yield call([Navigation, Navigation.push], componentId, {
       component: {
         name: SCREENS.RECOVERY.RestoreSeedSuccess,
         options: {
           topBar: {
-            visible: false,
-          },
-        },
-      },
+            visible: false
+          }
+        }
+      }
     })
     return true
   } catch (error) {
@@ -114,8 +142,11 @@ export function* performSeedRecovery({ phrase, componentId }) {
   }
 }
 
-function* recoverySaga() {
-  yield all([takeEvery(SHOW_RECOVERY_SEED, showSeed), takeEvery(START_SEED_RECOVERY, performSeedRecovery)])
+function * recoverySaga () {
+  yield all([
+    takeEvery(SHOW_RECOVERY_SEED, showSeed),
+    takeEvery(START_SEED_RECOVERY, performSeedRecovery)
+  ])
 }
 
 export default recoverySaga

--- a/lib/sagas/requests/disclosureRequest.js
+++ b/lib/sagas/requests/disclosureRequest.js
@@ -266,9 +266,9 @@ export function * askForNotificationsPermissions () {
   const endpoint = yield select(endpointArn)
   // console.log(`endpoint: ${endpoint}`)
   if (endpoint && endpoint.match(ARN_MATCHER)) return true
-  console.log('no endpoint')
-  const skipped = yield select(skippedPushNotifications)
-  console.log(`skipped push ${skipped}`)
+  // console.log('no endpoint')
+  // const skipped = yield select(skippedPushNotifications)
+  // console.log(`skipped push ${skipped}`)
   // if (skipped) return false
   yield put(registerDeviceForNotifications())
 }

--- a/lib/sagas/requests/index.js
+++ b/lib/sagas/requests/index.js
@@ -335,7 +335,7 @@ export function* returnToApp(url, response) {
 }
 
 export function* postBackToServer(request, response) {
-  console.log(`posting back to ${request.callback_url}`)
+  // console.log(`posting back to ${request.callback_url}`)
   let body
   if (request.boxPub) {
     const encrypted = yield call(encryptMessage, JSON.stringify(response), request.boxPub)
@@ -350,7 +350,7 @@ export function* postBackToServer(request, response) {
         Accept: 'application/json',
         'Content-Type': 'application/json',
       },
-      body,
+      body
     })
   } catch (e) {
     console.log(e)

--- a/lib/utilities/cache.js
+++ b/lib/utilities/cache.js
@@ -39,7 +39,7 @@ export function cacheOrFetch (key, f) {
           if (value) {
             // console.log(`caching: ${key}`)
             cache.setItem(key, value, (e, v) => {
-              if (e) console.log(e)
+              // if (e) console.log(e)
             })
           }
           resolve(value)


### PR DESCRIPTION
Migrated uport dids would be restored as uport dids but without the data.

This checks for presence of a backup first and then restores it as an ethr did.