### PR TITLE
[Support] increase packager timeout on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ jobs:
       - run:
           name: package react native android bundle independently
           command: yarn package-android --max-workers=3
+          no_output_timeout: 30m
       - persist_to_workspace:
           root: ~/uport-mobile
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
             - yarn-{{ arch }}-v5
       - run:
           name: package react native android bundle independently
-          command: yarn package-android --max-workers=3
+          command: yarn package-android --max-workers=2
           no_output_timeout: 30m
       - persist_to_workspace:
           root: ~/uport-mobile


### PR DESCRIPTION
this should fix the intermittent failures we're seeing during release builds