### PR TITLE
fix: force-configure ethr-did-resolver and the embedded credentials

### DIFF
--- a/lib/sagas/jwt.js
+++ b/lib/sagas/jwt.js
@@ -29,7 +29,9 @@ import registerEthrResolver from 'ethr-did-resolver'
 
 registerHttpsResolver()
 registerUportResolver()
-registerEthrResolver()
+
+const ethrConfig = {rpcUrl: "https://mainnet.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c"}
+registerEthrResolver(ethrConfig)
 
 export const DAY = 86400 // TODO determine this
 export const WEEK = DAY * 7
@@ -72,7 +74,9 @@ export function * signerFor (address, prompt) {
 }
 
 export function * credentialsFor (address, prompt, opts = {}) {
-  const params = {}
+  const params = {
+    ethrConfig: ethrConfig
+  }
   params.signer = yield signerFor(address, prompt)
   if (!!opts.issuer) {
     params.did = opts.issuer
@@ -101,7 +105,7 @@ export function * credentialsForRoot (address, prompt) {
     }
   }
 
-  return new Credentials({signer, did: `did:ethr:${address}`})
+  return new Credentials({signer, did: `did:ethr:${address}`, ethrConfig: ethrConfig})
 }
 
 // This is used for signing a JWT during recovery, when the datamodel is not fully recovered yet


### PR DESCRIPTION
patches the bug that is throwing the error thrown while verifying any ethr-did token:

[ethjs-query] while formatting outputs from RPC:
`{value:{code:-32600, message:"project ID is required", data: {reason: "project ID not provided", see:"https://infura.io/dashboard"}}}`